### PR TITLE
submodule info added

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Install the application using
 npm install
 ```
 
+### 
+The cql-tests folder has been added as a submodule. After pulling, you'll find a cql-tests folder inside cql-tests-runner. However, when you peek inside that folder, depending on your Git version, you might see nothing. Newer versions of Git will handle this automatically, but older versions may require you to explicitly instruct Git to download the contents of cql-tests.
+```
+git submodule update --init --recursive
+```
+
 ### Environment Variables
 Environment variables are set in the environment/global.json file:
  


### PR DESCRIPTION
I believe providing information about git submodules would be beneficial. It was a new concept for me, and it took a few minutes to understand why the cql-tests appeared empty.