### PR TITLE
added capabilities to the cql-tests-runner report

### DIFF
--- a/src/models/test-types.ts
+++ b/src/models/test-types.ts
@@ -20,6 +20,7 @@ export interface Test {
   ordered?: boolean;
   checkOrderedFunctions?: boolean;
   expression: string | TestExpression;
+  capability: CapabilityKV[];
   output?: string | TestOutput | string[] | TestOutput[];
 }
 
@@ -41,6 +42,11 @@ export interface Tests {
   group: TestGroup[];
 }
 
+export interface CapabilityKV {
+  code: string;
+  value?: string;
+}
+
 export interface TestResult {
   testStatus: 'pass' | 'fail' | 'skip' | 'error';
   responseStatus?: number;
@@ -57,5 +63,6 @@ export interface TestResult {
   testVersionTo?: string;
   invalid: 'false' | 'true' | 'semantic' | 'undefined';
   expression: string;
+  capability: CapabilityKV[];
   SkipMessage?: string;
 }

--- a/src/shared/results-shared.ts
+++ b/src/shared/results-shared.ts
@@ -1,4 +1,4 @@
-import { Tests, Test, TestResult } from '../models/test-types.js';
+import { Tests, Test, TestResult, CapabilityKV } from '../models/test-types.js';
 import { Parameters } from 'fhir/r4';
 
 export class Result {
@@ -17,6 +17,7 @@ export class Result {
   testVersionTo?: string;
   invalid: 'false' | 'true' | 'semantic' | 'undefined';
   expression: string;
+  capability: CapabilityKV[] = [];
 
   constructor(testsName: string, groupName: string, test: Test) {
     this.testsName = testsName;
@@ -48,6 +49,8 @@ export class Result {
     } else {
       this.testStatus = 'skip';
     }
+
+    this.capability = Array.isArray(test.capability) ? test.capability.map(({ code, value }) => ({ code, value })) : [];
   }
 }
 


### PR DESCRIPTION
The result looks like:
{
      "testStatus": "pass",
      "responseStatus": 200,
      "actual": 36,
      "expected": "36",
      "testsName": "CqlAggregateTest",
      "groupName": "AggregateTests",
      "testName": "MegaMulti",
      "testVersion": "1.5",
      "invalid": "false",
      "expression": "from ({1, 2}) X, ({1, 2}) Y, ({1, 2}) Z\n\t\t\t\t  aggregate Agg starting 0: Agg + X + Y + Z",
      "capability": [
        {
          "code": "multi-source-query"
        },
        {
          "code": "aggregate-clause-query"
        }
      ]
    }