### PR TITLE
Unescape CVL string content in CVL parser

### DIFF
--- a/cvl/cvl.mjs
+++ b/cvl/cvl.mjs
@@ -3,6 +3,7 @@ import antlr4 from 'antlr4';
 import cvlLexer from './.antlr/cvlLexer.mjs';
 import cvlParser from './.antlr/cvlParser.mjs';
 import cvlVisitor from './.antlr/cvlVisitor.mjs';
+import { unescapeString } from './string-escape-utils.mjs';
 
 class cvlParseVisitor extends cvlVisitor {
 	visitChildren(ctx) {
@@ -74,8 +75,7 @@ class cvlParseVisitor extends cvlVisitor {
 
 	// Visit a parse tree produced by cvlParser#stringLiteral.
 	visitStringLiteral(ctx) {
-		// TODO: Unescape
-		return ctx.getText().slice(1, -1);
+		return unescapeString(ctx.getText().slice(1, -1));
 	}
 
 

--- a/cvl/string-escape-utils.mjs
+++ b/cvl/string-escape-utils.mjs
@@ -1,0 +1,41 @@
+const UNESCAPE_MAP = new Map([
+	['\\"', '"'],
+	["\\'", "'"],
+	['\\`', '`'],
+	['\\\\', '\\'],
+	['\\/', '/'],
+	['\\f', '\f'],
+	['\\n', '\n'],
+	['\\r', '\r'],
+	['\\t', '\t'],
+	// Unicode escapes handled separately
+]);
+
+// Longer escape sequences should be matched first to avoid partial matches
+const MULTI_CHAR_UNESCAPE = [...UNESCAPE_MAP.keys()].toSorted((a, b) => b.length - a.length);
+
+const UNESCAPE_REGEX = new RegExp(
+	MULTI_CHAR_UNESCAPE.map(RegExp.escape).join('|') + '|\\\\u[0-9a-fA-F]{4}',
+	'g'
+);
+
+const HEX_RADIX = 16;
+
+/**
+ * Unescapes STRING content as per the CVL grammar. Based on CQL's [unescapeCql](https://github.com/cqframework/clinical_quality_language/blob/master/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/StringEscapeUtils.kt#L68).
+ *
+ * @param {string} input
+ * @returns {string}
+ */
+export function unescapeString(input) {
+	return input.replace(UNESCAPE_REGEX, match => {
+		if (UNESCAPE_MAP.has(match)) {
+			return UNESCAPE_MAP.get(match);
+		}
+		if (match.startsWith('\\u')) {
+			const hex = match.slice(2);
+			return String.fromCharCode(parseInt(hex, HEX_RADIX));
+		}
+		throw new Error(`Invalid escape sequence: ${match}`);
+	});
+}

--- a/test/cvl-parser.test.ts
+++ b/test/cvl-parser.test.ts
@@ -23,6 +23,24 @@ test('string literal', () => {
     ).toBe('abc');
 });
 
+// Based on https://github.com/cqframework/clinical_quality_language/blob/master/Src/java/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/StringEscapeUtilsTest.kt
+test('string literal with escape sequences', () => {
+	expect(_cvl.parse("'Hello \\'World\\''")).toBe("Hello 'World'");
+	expect(_cvl.parse('\'Hello \\"World\\"\'')).toBe('Hello "World"');
+	expect(_cvl.parse("'Hello \\`World\\`'")).toBe('Hello `World`');
+	expect(_cvl.parse("'Hello \\'World\\'2'")).toBe("Hello 'World'2");
+	expect(_cvl.parse('\'Hello \\"World\\"2\'')).toBe('Hello "World"2');
+	expect(_cvl.parse("'\\f\\n\\r\\t\\/\\\\'")).toBe('\u000c\n\r\t/\\');
+	expect(_cvl.parse("'\\u110f'")).toBe('ᄏ');
+	expect(
+		_cvl.parse(
+			'\'This is an identifier with \\"multiple\\" embedded \\t escapes\u0020\\r\\nno really, \\r\\n\\f\\t\\/\\\\lots of them\''
+		)
+	).toBe(
+		'This is an identifier with "multiple" embedded \t escapes\u0020\r\nno really, \r\n\u000c\t/\\lots of them'
+	);
+});
+
 test('number literal integer 1', () => {
     expect(_cvl.parse("1")
     ).toBe(1);


### PR DESCRIPTION
Implements the parsing of CVL's STRING tokens with escape sequences, e.g. `'\n'`. Equivalent to CQL's [`unescapeCql`](https://github.com/cqframework/clinical_quality_language/blob/master/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/StringEscapeUtils.kt#L68).

Closes https://github.com/cqframework/cql-tests-runner/issues/51