### PR TITLE
schema fix with testsRunDescription in the wrong place; fix for strin…

### DIFF
--- a/assets/schema/cql-test-configuration.schema.json
+++ b/assets/schema/cql-test-configuration.schema.json
@@ -44,12 +44,11 @@
           "type": "string",
           "pattern": "^\\d+\\.\\d+(\\.\\d+)?$",
           "description": "CQL engine version for version-based test filtering (optional)"
-        }
       },
       "testsRunDescription":{
         "type": "string",
-        "description": "Information about this test run",
-        "additionalProperties": false
+          "description": "Information about this test run"
+        }
       },
       "required": ["CqlFileVersion", "CqlOutputPath"],
       "additionalProperties": false

--- a/cvl/string-escape-utils.mjs
+++ b/cvl/string-escape-utils.mjs
@@ -10,12 +10,14 @@ const UNESCAPE_MAP = new Map([
 	['\\t', '\t'],
 	// Unicode escapes handled separately
 ]);
+const escapeRegex = (s) => s.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+
 
 // Longer escape sequences should be matched first to avoid partial matches
 const MULTI_CHAR_UNESCAPE = [...UNESCAPE_MAP.keys()].toSorted((a, b) => b.length - a.length);
 
 const UNESCAPE_REGEX = new RegExp(
-	MULTI_CHAR_UNESCAPE.map(RegExp.escape).join('|') + '|\\\\u[0-9a-fA-F]{4}',
+  	MULTI_CHAR_UNESCAPE.map(escapeRegex).join('|') + '|\\\\u[0-9a-fA-F]{4}',
 	'g'
 );
 


### PR DESCRIPTION
…g-escape-utils

This should fix the following 2 issues:

npx tsx src/bin/cql-tests.ts run-tests conf/development.json ./results
npm warn Unknown user config "pyls". This will stop working in the next major version of npm.
npm warn Unknown user config "/usr/bin/python3". This will stop working in the next major version of npm.
Warning: Could not validate configuration file conf/development.json: strict mode: unknown keyword: "testsRunDescription"
file:///Users/bryantaustin/Projects/cql-tests-runner/cvl/string-escape-utils.mjs:18
        MULTI_CHAR_UNESCAPE.map(RegExp.escape).join('|') + '|\\\\u[0-9a-fA-F]{4}',
                            ^

TypeError: undefined is not a function
    at Array.map (<anonymous>)
    at file:///Users/bryantaustin/Projects/cql-tests-runner/cvl/string-escape-utils.mjs:18:22
    at ModuleJob.run (node:internal/modules/esm/module_job:268:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:543:26)
    at async TestRunner.runTests (/Users/bryantaustin/Projects/cql-tests-runner/src/services/test-runner.ts:75:23)
    at async RunCommand.execute (/Users/bryantaustin/Projects/cql-tests-runner/src/commands/run-tests-command.ts:22:21)
    at async Command.<anonymous> (/Users/bryantaustin/Projects/cql-tests-runner/src/bin/cql-tests.ts:57:7)

Node.js v22.11.0

Raleigh did not get these errors. I had him test the changed  cvl file and worked on his machine, without breaking anything else.