### PR TITLE
Specify an exclusive set of tests to run using OnlyList

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install
 
 The cql-tests folder has been added as a submodule. After pulling, you'll find a cql-tests folder inside cql-tests-runner. However, when you peek inside that folder, depending on your Git version, you might see nothing. Newer versions of Git will handle this automatically, but older versions may require you to explicitly instruct Git to download the contents of cql-tests.
 
-```
+```bash
 git submodule update --init --recursive
 ```
 
@@ -37,29 +37,73 @@ git submodule update --init --recursive
 
 Configuration settings are set in a JSON configuration file. The file `conf/localhost.json` provides a sample configuration.
 
-```
+```json
 {
-    "FhirServer": {
-      "BaseUrl": "https://fhirServerBaseUrl",
-      "CqlOperation": "$cql"
-    },
-    "Build": {
-      "CqlFileVersion": "1.0.000",
-      "CqlOutputPath": "./cql",
-      "testsRunDescription": '',
-      "testsRunDescription": "Local host test run",
-      "cqlTranslator": "Java CQFramework Translator",
-      "cqlTranslatorVersion": "Unknown",
-      "cqlEngine": "Java CQFramework Engine",
-      "cqlEngineVersion": "4.1.0"
-    },
-    "Tests": {
-      "ResultsPath": "./results",
-      "SkipList": []
-    },
-    "Debug": {
-      "QuickTest": true
-    }
+  "FhirServer": {
+    "BaseUrl": "https://fhirServerBaseUrl",
+    "CqlOperation": "$cql"
+  },
+  "Build": {
+    "CqlFileVersion": "1.0.000",
+    "CqlOutputPath": "./cql",
+    "testsRunDescription": '',
+    "testsRunDescription": "Local host test run",
+    "cqlTranslator": "Java CQFramework Translator",
+    "cqlTranslatorVersion": "Unknown",
+    "cqlEngine": "Java CQFramework Engine",
+    "cqlEngineVersion": "4.1.0"
+  },
+  "Tests": {
+    "ResultsPath": "./results",
+    "SkipList": []
+  },
+  "Debug": {
+    "QuickTest": true
+  }
+}
+```
+
+To skip tests, add entries to the `SkipList` with the corresponding `testsName`, `groupName`, `testName`, and `reason`.
+
+```jsonc
+{
+  "FhirServer": {/* omitted */},
+  "Build": {/* omitted */},
+  "Tests": {
+    "ResultsPath": "./results",
+    "SkipList": [
+      {
+        "testsName": "CqlAggregateTest",
+        "groupName": "AggregateTests",
+        "testName": "RolledOutIntervals",
+        "reason": "CQLtoELM - Could not resolve identifier MedicationRequestIntervals in the current library"
+      },
+      // add more tests to skip as necessary...
+    ]
+  },
+  "Debug": {/* ommitted */}
+}
+```
+
+To run only a specified set of tests (and skip all others), add entries to the `OnlyList` with the corresponding `testsName`, `groupName`, and `testName`.
+
+```jsonc
+{
+  "FhirServer": {/* omitted */},
+  "Build": {/* omitted */},
+  "Tests": {
+    "ResultsPath": "./results",
+    "SkipList": [],
+    "OnlyList": [
+      {
+        "testsName": "CqlAggregateTest",
+        "groupName": "AggregateTests",
+        "testName": "RolledOutIntervals"
+      },
+      // add more tests to only run as necessary...
+    ]
+  },
+  "Debug": {/* ommitted */}
 }
 ```
 
@@ -265,6 +309,6 @@ Test cases are stored in the `test/` folder.
 
 Unit tests can be run from the command line using the following
 
-```
-$ npm run unit-tests
+```bash
+npm run unit-tests
 ```

--- a/assets/schema/cql-test-configuration.schema.json
+++ b/assets/schema/cql-test-configuration.schema.json
@@ -115,6 +115,29 @@
             "required": ["testsName", "groupName", "testName", "reason"],
             "additionalProperties": false
           }
+        },
+        "OnlyList": {
+          "type": "array",
+          "description": "List of tests to run exclusively",
+          "items": {
+            "type": "object",
+            "properties": {
+              "testsName": {
+                "type": "string",
+                "description": "Name of the test suite"
+              },
+              "groupName": {
+                "type": "string",
+                "description": "Name of the test group"
+              },
+              "testName": {
+                "type": "string",
+                "description": "Name of the specific test"
+              }
+            },
+            "required": ["testsName", "groupName", "testName"],
+            "additionalProperties": false
+          }
         }
       },
       "required": ["ResultsPath", "SkipList"],

--- a/src/commands/run-tests-command.ts
+++ b/src/commands/run-tests-command.ts
@@ -58,7 +58,34 @@ export class RunCommand {
 			},
 			Tests: {
 				ResultsPath: config.Tests.ResultsPath,
-				SkipList: config.Tests.SkipList,
+				SkipList: (() => {
+					const env = process.env.SKIP_LIST;
+					if (env !== undefined) {
+						try {
+							const parsed = JSON.parse(env);
+							return Array.isArray(parsed) ? parsed : [];
+						} catch {
+							console.warn(
+								'Failed to parse SKIP_LIST environment variable. Falling back to SkipList in config file.'
+							);
+						}
+					}
+					return config.Tests.SkipList;
+				})(),
+				OnlyList: (() => {
+					const env = process.env.ONLY_LIST;
+					if (env !== undefined) {
+						try {
+							const parsed = JSON.parse(env);
+							return Array.isArray(parsed) ? parsed : [];
+						} catch {
+							console.warn(
+								'Failed to parse ONLY_LIST environment variable. Falling back to OnlyList in config file.'
+							);
+						}
+					}
+					return config.Tests.OnlyList || [];
+				})()
 			},
 			Debug: {
 				QuickTest: quick !== undefined ? quick : config.Debug.QuickTest,

--- a/src/conf/config-loader.ts
+++ b/src/conf/config-loader.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Config, SkipItem } from '../models/config-types.js';
+import { Config, SkipItem, OnlyItem } from '../models/config-types.js';
 import { ConfigValidator, ValidationError } from './config-validator.js';
 
 export class ConfigLoader implements Config {
@@ -21,6 +21,7 @@ export class ConfigLoader implements Config {
 	Tests: {
 		ResultsPath: string;
 		SkipList: SkipItem[];
+		OnlyList?: OnlyItem[];
 	};
 	Debug: {
 		QuickTest: boolean;
@@ -67,7 +68,34 @@ export class ConfigLoader implements Config {
 
 		this.Tests = {
 			ResultsPath: process.env.RESULTS_PATH || configData.Tests?.ResultsPath || './results',
-			SkipList: process.env.SKIP_LIST || configData.Tests?.SkipList || [],
+			SkipList: (() => {
+				const env = process.env.SKIP_LIST;
+				if (env !== undefined) {
+					try {
+						const parsed = JSON.parse(env);
+						return Array.isArray(parsed) ? parsed : [];
+					} catch {
+						console.warn(
+							'Failed to parse SKIP_LIST environment variable. Falling back to SkipList in config file.'
+						);
+					}
+				}
+				return configData.Tests?.SkipList || [];
+			})(),
+			OnlyList: (() => {
+				const env = process.env.ONLY_LIST;
+				if (env !== undefined) {
+					try {
+						const parsed = JSON.parse(env);
+						return Array.isArray(parsed) ? parsed : [];
+					} catch {
+						console.warn(
+							'Failed to parse ONLY_LIST environment variable. Falling back to OnlyList in config file.'
+						);
+					}
+				}
+				return configData.Tests?.OnlyList || [];
+			})()
 		};
 
 		this.Debug = {
@@ -140,6 +168,15 @@ export class ConfigLoader implements Config {
 			])
 		);
 		return skipMap;
+	}
+
+	onlyListSet(): Set<string> {
+		const onlyList = this.Tests.OnlyList ?? [];
+		return new Set(
+			onlyList.map(
+				onlyItem => `${onlyItem.testsName}-${onlyItem.groupName}-${onlyItem.testName}`
+			)
+		);
 	}
 
 	#validateConfig(configPath: string, configData: any): void {

--- a/src/models/config-types.ts
+++ b/src/models/config-types.ts
@@ -5,6 +5,12 @@ export interface SkipItem {
 	reason: string;
 }
 
+export interface OnlyItem {
+	testsName: string;
+	groupName: string;
+	testName: string;
+}
+
 // Schema-compliant Config type (strictly matches cql-test-configuration.schema.json)
 export interface Config {
 	FhirServer: {
@@ -25,6 +31,7 @@ export interface Config {
 	Tests: {
 		ResultsPath: string;
 		SkipList: SkipItem[];
+		OnlyList?: OnlyItem[];
 	};
 	Debug: {
 		QuickTest: boolean;

--- a/src/server/config-utils.ts
+++ b/src/server/config-utils.ts
@@ -62,7 +62,34 @@ export function createConfigFromData(configData: any): ConfigLoader {
 
   config.Tests = {
     ResultsPath: process.env.RESULTS_PATH || configData.Tests?.ResultsPath || './results',
-    SkipList: process.env.SKIP_LIST || configData.Tests?.SkipList || []
+    SkipList: (() => {
+      const env = process.env.SKIP_LIST;
+      if (env !== undefined) {
+        try {
+          const parsed = JSON.parse(env);
+          return Array.isArray(parsed) ? parsed : [];
+        } catch {
+          console.warn(
+            'Failed to parse SKIP_LIST environment variable. Falling back to SkipList in config file.'
+          );
+        }
+      }
+      return configData.Tests?.SkipList || [];
+    })(),
+    OnlyList: (() => {
+      const env = process.env.ONLY_LIST;
+      if (env !== undefined) {
+        try {
+          const parsed = JSON.parse(env);
+          return Array.isArray(parsed) ? parsed : [];
+        } catch {
+          console.warn(
+            'Failed to parse ONLY_LIST environment variable. Falling back to OnlyList in config file.'
+          );
+        }
+      }
+      return configData.Tests?.OnlyList || [];
+    })()
   };
 
   config.Debug = {

--- a/src/server/test-execution-service.ts
+++ b/src/server/test-execution-service.ts
@@ -23,6 +23,7 @@ interface ExecutionContext {
   tests: Tests[];
   resultExtractor: ResultExtractor;
   skipMap: Map<string, string>;
+  onlySet: Set<string>;
 }
 
 export class TestExecutionService {
@@ -54,8 +55,9 @@ export class TestExecutionService {
     const tests = TestLoader.load();
     const resultExtractor = buildExtractor();
     const skipMap = config.skipListMap();
+    const onlySet = config.onlyListSet();
 
-    return { config, cqlEngine, cvl, tests, resultExtractor, skipMap };
+    return { config, cqlEngine, cvl, tests, resultExtractor, skipMap, onlySet };
   }
 
   /**
@@ -67,12 +69,17 @@ export class TestExecutionService {
     cvl: any,
     resultExtractor: ResultExtractor,
     skipMap: Map<string, string>,
+    onlySet: Set<string>,
     config: ConfigLoader
   ): Promise<InternalTestResult> {
     const key = `${result.testsName}-${result.groupName}-${result.testName}`;
 
     if (result.testStatus === 'skip') {
       result.SkipMessage = 'Skipped by cql-tests-runner';
+      return result;
+    } else if (onlySet.size > 0 && !onlySet.has(key)) {
+      result.SkipMessage = 'Skipped by OnlyList filter';
+      result.testStatus = 'skip';
       return result;
     } else if (skipMap.has(key)) {
       const reason = skipMap.get(key) || '';
@@ -127,7 +134,7 @@ export class TestExecutionService {
    */
   async runTests(configData: any): Promise<any> {
     const ctx = await this.createExecutionContext(configData);
-    const { config, cqlEngine, cvl, tests, resultExtractor, skipMap } = ctx;
+    const { config, cqlEngine, cvl, tests, resultExtractor, skipMap, onlySet } = ctx;
 
     const quickTest = config.Debug?.QuickTest || false;
     const emptyResults = await generateEmptyResults(tests, quickTest);
@@ -135,7 +142,7 @@ export class TestExecutionService {
 
     for (const testFile of emptyResults) {
       for (const result of testFile) {
-        await this.runTest(result, cqlEngine.apiUrl!, cvl, resultExtractor, skipMap, config);
+        await this.runTest(result, cqlEngine.apiUrl!, cvl, resultExtractor, skipMap, onlySet, config);
         results.add(result);
       }
     }
@@ -153,7 +160,7 @@ export class TestExecutionService {
     configData: any
   ): Promise<any> {
     const ctx = await this.createExecutionContext(configData);
-    const { config, cqlEngine, cvl, tests, resultExtractor, skipMap } = ctx;
+    const { config, cqlEngine, cvl, tests, resultExtractor, skipMap, onlySet } = ctx;
 
     for (const testSuite of tests) {
       if (testSuite.name !== testsName) continue;
@@ -163,7 +170,7 @@ export class TestExecutionService {
           if (test.name !== testName) continue;
 
           const result = new Result(testsName, groupName, test);
-          await this.runTest(result, cqlEngine.apiUrl!, cvl, resultExtractor, skipMap, config);
+          await this.runTest(result, cqlEngine.apiUrl!, cvl, resultExtractor, skipMap, onlySet, config);
 
           const testResults = new CQLTestResults(cqlEngine);
           testResults.add(result);
@@ -184,7 +191,7 @@ export class TestExecutionService {
     configData: any
   ): Promise<any[]> {
     const ctx = await this.createExecutionContext(configData);
-    const { config, cqlEngine, cvl, tests, resultExtractor, skipMap } = ctx;
+    const { config, cqlEngine, cvl, tests, resultExtractor, skipMap, onlySet } = ctx;
 
     const results = new CQLTestResults(cqlEngine);
 
@@ -194,7 +201,7 @@ export class TestExecutionService {
         if (group.name !== groupName || !group.test) continue;
         for (const test of group.test) {
           const result = new Result(testsName, groupName, test);
-          await this.runTest(result, cqlEngine.apiUrl!, cvl, resultExtractor, skipMap, config);
+          await this.runTest(result, cqlEngine.apiUrl!, cvl, resultExtractor, skipMap, onlySet, config);
           results.add(result);
         }
         return results.toJSON().results;

--- a/src/services/test-runner.ts
+++ b/src/services/test-runner.ts
@@ -53,6 +53,7 @@ export class TestRunner {
 		const resultExtractor = buildExtractor();
 		const emptyResults = await generateEmptyResults(tests, quickTest);
 		const skipMap = config.skipListMap();
+		const onlySet = config.onlyListSet();
 
 		const results = new CQLTestResults(cqlEngine);
 
@@ -82,6 +83,7 @@ export class TestRunner {
 					cvl,
 					resultExtractor,
 					skipMap,
+					onlySet,
 					config,
 					options.useAxios
 				);
@@ -107,6 +109,7 @@ export class TestRunner {
 		cvl: any,
 		resultExtractor: ResultExtractor,
 		skipMap: Map<string, string>,
+		onlySet: Set<string>,
 		config: ConfigLoader,
 		useAxios: boolean = false
 	): Promise<InternalTestResult> {
@@ -114,6 +117,10 @@ export class TestRunner {
 
 		if (result.testStatus === 'skip') {
 			result.SkipMessage = 'Skipped by cql-tests-runner';
+			return result;
+		} else if (onlySet.size > 0 && !onlySet.has(key)) {
+			result.SkipMessage = 'Skipped by OnlyList filter';
+			result.testStatus = 'skip';
 			return result;
 		} else if (skipMap.has(key)) {
 			const reason = skipMap.get(key) || '';

--- a/test/run-tests.test.ts
+++ b/test/run-tests.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { TestRunner } from '../src/services/test-runner.js';
+import * as ResultsUtils from '../src/shared/results-utils.js';
+
+vi.mock('../src/loaders/test-loader', () => ({
+  TestLoader: { load: vi.fn().mockReturnValue([]) },
+}));
+
+const makeResult = (testsName: string, groupName: string, testName: string) => ({
+  testsName,
+  groupName,
+  testName,
+  expression: 'true',
+  expected: 'true',
+  invalid: 'false',
+  capability: [],
+});
+
+vi.mock('../src/shared/results-shared', () => ({
+  generateEmptyResults: vi
+    .fn()
+    .mockImplementation(async () => [
+      [makeResult('Suite1', 'Group1', 'Test1'), makeResult('Suite1', 'Group1', 'Test2')],
+    ]),
+  generateParametersResource: vi.fn().mockReturnValue({}),
+}));
+
+const baseConfig = {
+  FhirServer: { BaseUrl: 'http://localhost:8080/fhir', CqlOperation: '$cql' },
+  Build: {},
+  Debug: { QuickTest: false },
+  Tests: { ResultsPath: './results', SkipList: [] as any[], OnlyList: [] as any[] },
+};
+
+describe('RunTests filtering (TestRunner)', () => {
+  let runner: TestRunner;
+  let fetchSpy: Mock;
+  let resultsEqualSpy: Mock;
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({}),
+    } as Response);
+    resultsEqualSpy = vi.spyOn(ResultsUtils, 'resultsEqual').mockReturnValue(true);
+    runner = new TestRunner();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (process.env as any).ONLY_LIST;
+    delete (process.env as any).SKIP_LIST;
+  });
+
+  it('runs all tests when SkipList and OnlyList are empty', async () => {
+    const config = {
+      ...baseConfig,
+      Tests: {
+        ResultsPath: './results',
+        SkipList: [],
+        OnlyList: [],
+      },
+    };
+
+    const results = await runner.runTests(config, { useAxios: false });
+    const test1 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test1'
+    );
+    const test2 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test2'
+    );
+    expect(test1?.testStatus).toBe('pass');
+    expect(test2?.testStatus).toBe('pass');
+    expect(results.toJSON().testResultsSummary).toEqual({
+      passCount: 2,
+      skipCount: 0,
+      failCount: 0,
+      errorCount: 0,
+    });
+  });
+
+  it('skips tests in SkipList', async () => {
+    const config = {
+      FhirServer: { BaseUrl: 'http://localhost:8080/fhir', CqlOperation: '$cql' },
+      Build: {},
+      Debug: { QuickTest: false },
+      Tests: {
+        ResultsPath: './results',
+        SkipList: [
+          {
+            testsName: 'Suite1',
+            groupName: 'Group1',
+            testName: 'Test1',
+            reason: 'Disabled',
+          },
+        ],
+      },
+    };
+
+    const results = await runner.runTests(config, { useAxios: false });
+    const test1 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test1'
+    );
+    const test2 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test2'
+    );
+    expect(test1?.testStatus).toBe('skip');
+    expect(test2?.testStatus).toBe('pass');
+    expect(results.toJSON().testResultsSummary).toEqual({
+      passCount: 1,
+      skipCount: 1,
+      failCount: 0,
+      errorCount: 0,
+    });
+  });
+
+  it('runs only tests in OnlyList (others skipped)', async () => {
+    const config = {
+      ...baseConfig,
+      Tests: {
+        ...baseConfig.Tests,
+        OnlyList: [{ testsName: 'Suite1', groupName: 'Group1', testName: 'Test2' }],
+      },
+    };
+
+    const results = await runner.runTests(config, { useAxios: false });
+    // Two tests total in our mock, one should be run (pass), the other skipped
+    const statuses = results.results.map(r => ({
+      key: `${r.testsName}-${r.groupName}-${r.testName}`,
+      status: r.testStatus,
+    }));
+    expect(statuses).toContainEqual({ key: 'Suite1-Group1-Test2', status: 'pass' });
+    expect(statuses).toContainEqual({ key: 'Suite1-Group1-Test1', status: 'skip' });
+    expect(results.toJSON().testResultsSummary).toEqual({
+      passCount: 1,
+      skipCount: 1,
+      failCount: 0,
+      errorCount: 0,
+    });
+  });
+
+  it('skips a test present in both OnlyList and SkipList', async () => {
+    const config = {
+      ...baseConfig,
+      Tests: {
+        ...baseConfig.Tests,
+        OnlyList: [{ testsName: 'Suite1', groupName: 'Group1', testName: 'Test2' }],
+        SkipList: [
+          {
+            testsName: 'Suite1',
+            groupName: 'Group1',
+            testName: 'Test2',
+            reason: 'Disabled',
+          },
+        ],
+      },
+    };
+
+    const results = await runner.runTests(config, { useAxios: false });
+    const test2 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test2'
+    );
+    const test1 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test1'
+    );
+    expect(test2?.testStatus).toBe('skip');
+    expect(test1?.testStatus).toBe('skip');
+    expect(results.toJSON().testResultsSummary).toEqual({
+      passCount: 0,
+      skipCount: 2,
+      failCount: 0,
+      errorCount: 0,
+    });
+  });
+
+  it('reports failure for unequal results', async () => {
+    resultsEqualSpy.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    const config = {
+      ...baseConfig,
+      Tests: {
+        ResultsPath: './results',
+        SkipList: [],
+        OnlyList: [],
+      },
+    };
+
+    const results = await runner.runTests(config, { useAxios: false });
+    const test1 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test1'
+    );
+    const test2 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test2'
+    );
+    expect(test1?.testStatus).toBe('pass');
+    expect(test2?.testStatus).toBe('fail');
+    expect(results.toJSON().testResultsSummary).toEqual({
+      passCount: 1,
+      skipCount: 0,
+      failCount: 1,
+      errorCount: 0,
+    });
+  });
+
+  it('reports failure for HTTP 500 result', async () => {
+    fetchSpy
+      // server connectivity
+      .mockResolvedValueOnce({
+        status: 200,
+        json: () => Promise.resolve({}),
+      } as Response)
+      // test 1
+      .mockResolvedValueOnce({
+        status: 500,
+        json: () => Promise.resolve({}),
+      } as Response)
+      // test 2 and beyond
+      .mockResolvedValue({
+        status: 200,
+        json: () => Promise.resolve({}),
+      } as Response);
+
+    const config = {
+      ...baseConfig,
+      Tests: {
+        ResultsPath: './results',
+        SkipList: [],
+        OnlyList: [],
+      },
+    };
+
+    const results = await runner.runTests(config, { useAxios: false });
+    const test1 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test1'
+    );
+    const test2 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test2'
+    );
+    expect(test1?.testStatus).toBe('fail');
+    expect(test2?.testStatus).toBe('pass');
+    expect(results.toJSON().testResultsSummary).toEqual({
+      passCount: 1,
+      skipCount: 0,
+      failCount: 1,
+      errorCount: 0,
+    });
+  });
+
+  it('reports error for thrown error on fetch', async () => {
+    fetchSpy.mockReset();
+    fetchSpy
+      // server connectivity
+      .mockResolvedValueOnce({
+        status: 200,
+        json: () => Promise.resolve({}),
+      } as Response)
+      // test 1
+      .mockRejectedValueOnce(new Error('error'))
+      // test 2 and beyond
+      .mockResolvedValue({
+        status: 200,
+        json: () => Promise.resolve({}),
+      } as Response);
+
+    const config = {
+      ...baseConfig,
+      Tests: {
+        ResultsPath: './results',
+        SkipList: [],
+        OnlyList: [],
+      },
+    };
+
+    const results = await runner.runTests(config, { useAxios: false });
+    const test1 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test1'
+    );
+    const test2 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test2'
+    );
+    expect(test1?.testStatus).toBe('error');
+    expect(test2?.testStatus).toBe('pass');
+    expect(results.toJSON().testResultsSummary).toEqual({
+      passCount: 1,
+      skipCount: 0,
+      failCount: 0,
+      errorCount: 1,
+    });
+  });
+
+  it('SKIP_LIST env var overrides config Tests.SkipList', async () => {
+    const config = {
+      ...baseConfig,
+      Tests: {
+        ...baseConfig.Tests,
+        // Config SkipList skips Test1, but env will skip Test2 instead
+        SkipList: [
+          { testsName: 'Suite1', groupName: 'Group1', testName: 'Test1', reason: 'Cfg' },
+        ],
+        OnlyList: [],
+      },
+    };
+
+    process.env.SKIP_LIST = JSON.stringify([
+      { testsName: 'Suite1', groupName: 'Group1', testName: 'Test2', reason: 'Env' },
+    ]);
+
+    const results = await runner.runTests(config, { useAxios: false });
+    const test1 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test1'
+    );
+    const test2 = results.results.find(
+      r => r.testsName === 'Suite1' && r.groupName === 'Group1' && r.testName === 'Test2'
+    );
+    expect(test1?.testStatus).toBe('pass');
+    expect(test2?.testStatus).toBe('skip');
+    expect(results.toJSON().testResultsSummary).toEqual({
+      passCount: 1,
+      skipCount: 1,
+      failCount: 0,
+      errorCount: 0,
+    });
+  });
+
+  it('ONLY_LIST env var overrides config Tests.OnlyList', async () => {
+    const config = {
+      ...baseConfig,
+      Tests: {
+        ...baseConfig.Tests,
+        // Config says run Test1
+        OnlyList: [{ testsName: 'Suite1', groupName: 'Group1', testName: 'Test1' }],
+      },
+    };
+
+    // Env says run Test2 instead
+    process.env.ONLY_LIST = JSON.stringify([
+      { testsName: 'Suite1', groupName: 'Group1', testName: 'Test2' },
+    ]);
+
+    const results = await runner.runTests(config, { useAxios: false });
+    const statuses = results.results.map(r => ({
+      key: `${r.testsName}-${r.groupName}-${r.testName}`,
+      status: r.testStatus,
+    }));
+    expect(statuses).toContainEqual({ key: 'Suite1-Group1-Test2', status: 'pass' });
+    expect(statuses).toContainEqual({ key: 'Suite1-Group1-Test1', status: 'skip' });
+    expect(results.toJSON().testResultsSummary).toEqual({
+      passCount: 1,
+      skipCount: 1,
+      failCount: 0,
+      errorCount: 0,
+    });
+  });
+});

--- a/test/server-command.test.ts
+++ b/test/server-command.test.ts
@@ -45,6 +45,7 @@ vi.mock('../src/conf/config-loader', () => ({
       QuickTest: configData?.Debug?.QuickTest || false,
     };
     this.skipListMap = vi.fn().mockReturnValue(new Map());
+    this.onlyListSet = vi.fn().mockReturnValue(new Set());
     return this;
   }),
 }));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 		globals: true,
 		environment: 'node',
 		exclude: ['**/node_modules/**', '**/dist/**', '**/.{idea,git,cache,output,temp}/**'],
+		silent: true,
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
Sometimes when you are working on a fixing only a few tests, it's annoying to have to run the full suite of 1700+ tests every time you want to test your fixes. For this reason, I've added an `OnlyList` to the configuration. If the `OnlyList` is non-empty, then only the tests in the `OnlyList` will be run; all other tests are skipped.

This PR introduces the following changes:
- Add `OnlyList` to configuration schema
- Run only tests in `OnlyList` when it is specified with at least one item
- Allow overriding `OnlyList` config using `ONLY_LIST` environment variable
- Fix processing of existing `SKIP_LIST` environment variable
- Add new `run-tests.test.ts` test suite with tests that cover different combinations of `SkipList` and `OnlyList`
- Run `npm audit fix` to address reported vulnerabilities

Note that although there is a `.prettierrc` in the project root, I found that if I applied it to the files I changed, there were quite a few formatting changes (to the extent that it was difficult to see the true changes I made). For that reason I've opted _not_ to apply prettier to my edited files and am only including the true logical changes. I've also noticed that there is a mix of tabs and spaces across the project. I tried to follow whichever seemed to be the prevalent convention in each file. Perhaps prettier can be applied across the whole project at another time.

To test, specify one or more tests in the `OnlyList` and confirm that they are the only ones run. See README for an example of the `OnlyList` configuration.