### PR TITLE
Allow overriding the test directory via CQL_TESTS_PATH

### DIFF
--- a/src/loaders/test-loader.ts
+++ b/src/loaders/test-loader.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { XMLParser, type X2jOptions } from 'fast-xml-parser';
 import { Tests } from '../models/test-types.js';
 
-const testsPath = 'cql-tests/tests/cql';
+const testsPath = process.env.CQL_TESTS_PATH || 'cql-tests/tests/cql';
 
 const alwaysArray = ['tests.group', 'tests.group.test'];
 


### PR DESCRIPTION
TestLoader's path was hardcoded to cql-tests/tests/cql. Read an optional CQL_TESTS_PATH env var (falling back to the default) so different suites — e.g. connectathonTests vs mainTests — can be run without editing source.