### PR TITLE
Render list results in CQL list syntax in the results file

### DIFF
--- a/src/test-results/cql-test-results.ts
+++ b/src/test-results/cql-test-results.ts
@@ -6,6 +6,21 @@ import { TestResultsSummary, CQLTestResultsData } from '../models/results-types.
 import { ResultsValidator } from '../conf/results-validator.js';
 
 /**
+ * Formats an actual value for the results file. Lists are rendered in CQL list
+ * syntax (`{ a, b, c }`) so they read like the expected value, which is kept in
+ * its original CQL/CVL notation.
+ */
+function formatActualValue(value: any): string {
+	if (Array.isArray(value)) {
+		return value.length === 0 ? '{}' : `{ ${value.map(formatActualValue).join(', ')} }`;
+	}
+	if (value !== null && typeof value === 'object') {
+		return JSON.stringify(value);
+	}
+	return String(value);
+}
+
+/**
  * Represents the results of running CQL tests.
  */
 export class CQLTestResults {
@@ -106,7 +121,7 @@ export class CQLTestResults {
 				...(result.responseStatus !== undefined && {
 					responseStatus: result.responseStatus,
 				}),
-				...(result.actual !== undefined && { actual: String(result.actual) }),
+				...(result.actual !== undefined && { actual: formatActualValue(result.actual) }),
 				...(result.expected && { expected: result.expected }),
 				...(result.error && {
 					error: {
@@ -188,8 +203,9 @@ export class CQLTestResults {
 			} else if (typeof act === 'number' && typeof exp === 'string') {
 				r.actual = String(act);
 			} else if (act !== undefined && act !== null && typeof act !== 'string') {
-				// Convert any non-string value to string for schema compliance
-				r.actual = String(act);
+				// Convert any non-string value to string for schema compliance;
+				// lists are rendered in CQL list syntax to mirror the expected value
+				r.actual = formatActualValue(act);
 			}
 		}
 	}

--- a/test/cql-test-results-validator.test.ts
+++ b/test/cql-test-results-validator.test.ts
@@ -129,3 +129,67 @@ describe('CQLTestResults.validateSchema', () => {
     expect(ResultsValidator).toHaveBeenCalled();
   });
 });
+
+describe('CQLTestResults.toJSON actual serialization', () => {
+  it('renders list results in CQL list syntax and stringifies scalar results', () => {
+    const results = new CQLTestResults(new CQLEngine('http://localhost:8080/fhir/$cql'));
+    results.add({
+      testsName: 'CqlListOperatorsTest',
+      groupName: 'Sort',
+      testName: 'SortDatesAsc',
+      expression: 'sort asc',
+      testStatus: 'fail',
+      invalid: 'false',
+      actual: ['@2012-01-01T', '@2012-01-01T12'],
+      expected: '{ @2012-01-01T, @2012-01-01T12 }',
+    } as any);
+    results.add({
+      testsName: 'CqlArithmeticFunctionsTest',
+      groupName: 'Power',
+      testName: 'Power2To4',
+      expression: '2^4',
+      testStatus: 'pass',
+      invalid: 'false',
+      actual: 16,
+      expected: '16',
+    } as any);
+
+    const json = results.toJSON();
+    expect(json.results[0].actual).toBe('{ @2012-01-01T, @2012-01-01T12 }');
+    expect(json.results[1].actual).toBe('16');
+  });
+
+  it('equalizeValueTypes renders array actuals in CQL list syntax', () => {
+    const results = new CQLTestResults(new CQLEngine('http://localhost:8080/fhir/$cql'));
+    results.add({
+      testsName: 'T',
+      groupName: 'G',
+      testName: 'N',
+      expression: 'e',
+      testStatus: 'pass',
+      invalid: 'false',
+      actual: [1, 2, 3],
+      expected: '{ 1, 2, 3 }',
+    } as any);
+
+    results.equalizeValueTypes();
+    expect(results.results[0].actual).toBe('{ 1, 2, 3 }');
+  });
+
+  it('renders nested lists and empty lists', () => {
+    const results = new CQLTestResults(new CQLEngine('http://localhost:8080/fhir/$cql'));
+    results.add({
+      testsName: 'T',
+      groupName: 'G',
+      testName: 'Nested',
+      expression: 'e',
+      testStatus: 'pass',
+      invalid: 'false',
+      actual: [[1, 2], []],
+      expected: '{ { 1, 2 }, {} }',
+    } as any);
+
+    const json = results.toJSON();
+    expect(json.results[0].actual).toBe('{ { 1, 2 }, {} }');
+  });
+});


### PR DESCRIPTION
List-typed actual values were flattened with `String()` when writing the results file, so a list like `['@2012-01-01T', '@2012-01-01T12']` appeared as the comma-joined string `@2012-01-01T,@2012-01-01T12`. That obscures the list structure and makes failures hard to read — e.g. for `CqlListOperatorsTest / Sort / SortDatesAsc`, the only difference from the expected value was element order, which was invisible in the flattened form.

## Changes

- `src/test-results/cql-test-results.ts`: added a `formatActualValue` helper that renders array actuals in CQL list syntax — `{ a, b, c }`, recursing into nested lists, `{}` for empty lists — so the actual value reads like the expected value's CQL/CVL notation. Non-array objects fall back to `JSON.stringify`, scalars to `String()` as before. Used by both `toJSON` and `equalizeValueTypes`.
- `actual` remains a plain string, so the results JSON schema and downstream consumers of results files are unaffected.

Before / after for `SortDatesAsc`:

```json
"actual":   "@2012-01-01T12,@2012-01-01T,@2012-10-05T,@2012-10-05T10"
```

```json
"actual":   "{ @2012-01-01T12, @2012-01-01T, @2012-10-05T, @2012-10-05T10 }",
"expected": "{ @2012-01-01T, @2012-01-01T12, @2012-10-05T, @2012-10-05T10 }"
```

Note: string elements are not re-quoted (a CQL `{ 'a', 'b' }` renders as `{ a, b }`), since the extracted values no longer carry type information. This only affects display in the results file; pass/fail comparison happens before formatting and is unchanged.

## Testing

- Unit tests for list, scalar, nested-list, and empty-list rendering in `toJSON` and `equalizeValueTypes`.
- Full suite passes (125 tests) and `tsc --noEmit` is clean.
- Verified end to end by running `run-tests` against a mock FHIR server returning repeated `return` parameters — the results file shows the CQL-list-formatted actual above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6fK2KhnNsn28SJfe83Htw

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6fK2KhnNsn28SJfe83Htw)_