### PR TITLE
Extract Date/Time intervals from Periods via cqf-cqlType and render interval/quantity actuals in CQL syntax

### DIFF
--- a/src/extractors/value-type-extractors/datetime-interval-extractor.ts
+++ b/src/extractors/value-type-extractors/datetime-interval-extractor.ts
@@ -1,15 +1,38 @@
 import { BaseExtractor } from '../base-extractor.js';
-import { format_datetime } from './value-type-extractor-utils.js';
+import { format_datetime, format_time } from './value-type-extractor-utils.js';
+
+const CQL_TYPE_URL = 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType';
+const TIME_INTERVAL_TYPE = /^Interval<(?:System\.)?Time>$/;
+
+/**
+ * True when the parameter's cqf-cqlType extension declares `Interval<System.Time>`
+ * (the `System.` prefix is optional). FHIR Period cannot hold times, so a time
+ * interval arrives with its boundaries anchored to a placeholder date and only the
+ * extension identifies the real point type.
+ */
+function isTimeInterval(parameter: any): boolean {
+	if (!Array.isArray(parameter.extension)) {
+		return false;
+	}
+	const extension = parameter.extension.find(
+		(e: any) => e !== null && typeof e === 'object' && e.url === CQL_TYPE_URL
+	);
+	return (
+		extension !== undefined &&
+		typeof extension.valueString === 'string' &&
+		TIME_INTERVAL_TYPE.test(extension.valueString)
+	);
+}
 
 export class DateTimeIntervalExtractor extends BaseExtractor {
 	protected _process(parameter: any): any {
-		// TODO: Use the cqlType extension to establish the point type of the interval
 		if (parameter.hasOwnProperty('valuePeriod')) {
+			const format = isTimeInterval(parameter) ? format_time : format_datetime;
 			const low = parameter.valuePeriod.hasOwnProperty('start')
-				? format_datetime(parameter.valuePeriod.start)
+				? format(parameter.valuePeriod.start)
 				: null;
 			const high = parameter.valuePeriod.hasOwnProperty('end')
-				? format_datetime(parameter.valuePeriod.end)
+				? format(parameter.valuePeriod.end)
 				: null;
 			return {
 				lowClosed: low !== null,

--- a/src/extractors/value-type-extractors/datetime-interval-extractor.ts
+++ b/src/extractors/value-type-extractors/datetime-interval-extractor.ts
@@ -1,33 +1,40 @@
 import { BaseExtractor } from '../base-extractor.js';
-import { format_datetime, format_time } from './value-type-extractor-utils.js';
+import { format_date, format_datetime, format_time } from './value-type-extractor-utils.js';
 
 const CQL_TYPE_URL = 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType';
-const TIME_INTERVAL_TYPE = /^Interval<(?:System\.)?Time>$/;
+const TEMPORAL_INTERVAL_TYPE = /^Interval<(?:System\.)?(Date|DateTime|Time)>$/;
 
 /**
- * True when the parameter's cqf-cqlType extension declares `Interval<System.Time>`
- * (the `System.` prefix is optional). FHIR Period cannot hold times, so a time
- * interval arrives with its boundaries anchored to a placeholder date and only the
- * extension identifies the real point type.
+ * The point type declared by the parameter's cqf-cqlType extension, when it names a
+ * temporal interval (the `System.` prefix is optional). FHIR Period boundaries are
+ * always dateTimes — a time interval arrives anchored to a placeholder date, and a
+ * date interval may pick up a time part — so only the extension identifies the real
+ * point type.
  */
-function isTimeInterval(parameter: any): boolean {
+function declaredPointType(parameter: any): 'Date' | 'DateTime' | 'Time' | undefined {
 	if (!Array.isArray(parameter.extension)) {
-		return false;
+		return undefined;
 	}
 	const extension = parameter.extension.find(
 		(e: any) => e !== null && typeof e === 'object' && e.url === CQL_TYPE_URL
 	);
-	return (
-		extension !== undefined &&
-		typeof extension.valueString === 'string' &&
-		TIME_INTERVAL_TYPE.test(extension.valueString)
-	);
+	if (extension === undefined || typeof extension.valueString !== 'string') {
+		return undefined;
+	}
+	const match = TEMPORAL_INTERVAL_TYPE.exec(extension.valueString);
+	return match === null ? undefined : (match[1] as 'Date' | 'DateTime' | 'Time');
 }
+
+const BOUNDARY_FORMATS = {
+	Date: format_date,
+	DateTime: format_datetime,
+	Time: format_time,
+};
 
 export class DateTimeIntervalExtractor extends BaseExtractor {
 	protected _process(parameter: any): any {
 		if (parameter.hasOwnProperty('valuePeriod')) {
-			const format = isTimeInterval(parameter) ? format_time : format_datetime;
+			const format = BOUNDARY_FORMATS[declaredPointType(parameter) ?? 'DateTime'];
 			const low = parameter.valuePeriod.hasOwnProperty('start')
 				? format(parameter.valuePeriod.start)
 				: null;

--- a/src/extractors/value-type-extractors/value-type-extractor-utils.ts
+++ b/src/extractors/value-type-extractors/value-type-extractor-utils.ts
@@ -1,4 +1,17 @@
 /**
+ * Formats a Period boundary of an `Interval<System.Date>` as a CQL Date literal.
+ * Unlike `format_datetime`, no trailing `T` is appended: `@2018-01-01T` is a
+ * DateTime literal, while a date interval's boundaries must stay `@2018-01-01`.
+ * A time part, if an engine includes one, is an artifact of the Period mapping
+ * and is stripped.
+ */
+export function format_date(datetime: string): string {
+	const value = datetime.toString();
+	const timeStart = value.indexOf('T');
+	return `@${timeStart >= 0 ? value.slice(0, timeStart) : value}`;
+}
+
+/**
  * Formats a Period boundary of an `Interval<System.Time>` as a CQL Time literal.
  * FHIR Period boundaries are dateTimes, so engines anchor the time-of-day to a
  * placeholder date (e.g. 0001-01-01); that date — and any timezone offset, which

--- a/src/extractors/value-type-extractors/value-type-extractor-utils.ts
+++ b/src/extractors/value-type-extractors/value-type-extractor-utils.ts
@@ -1,3 +1,16 @@
+/**
+ * Formats a Period boundary of an `Interval<System.Time>` as a CQL Time literal.
+ * FHIR Period boundaries are dateTimes, so engines anchor the time-of-day to a
+ * placeholder date (e.g. 0001-01-01); that date — and any timezone offset, which
+ * a CQL Time cannot carry — is an artifact of the mapping and is stripped.
+ */
+export function format_time(datetime: string): string {
+	const value = datetime.toString();
+	const timeStart = value.indexOf('T');
+	const time = timeStart >= 0 ? value.slice(timeStart + 1) : value;
+	return `@T${time.replace(/(?:Z|[+-]\d{2}:\d{2})$/, '')}`;
+}
+
 export function format_datetime(datetime: string): string {
 	let dt = `@${datetime.toString()}`;
 	if (dt.length <= 11) {

--- a/src/test-results/cql-test-results.ts
+++ b/src/test-results/cql-test-results.ts
@@ -6,18 +6,45 @@ import { TestResultsSummary, CQLTestResultsData } from '../models/results-types.
 import { ResultsValidator } from '../conf/results-validator.js';
 
 /**
- * Formats an actual value for the results file. Lists are rendered in CQL list
- * syntax (`{ a, b, c }`) so they read like the expected value, which is kept in
- * its original CQL/CVL notation.
+ * Formats an actual value for the results file. Lists (`{ a, b, c }`), intervals
+ * (`Interval[low, high)`) and quantities (`2.0 'cm2'`) are rendered in CQL syntax
+ * so they read like the expected value, which is kept in its original CQL/CVL
+ * notation.
  */
 function formatActualValue(value: any): string {
 	if (Array.isArray(value)) {
 		return value.length === 0 ? '{}' : `{ ${value.map(formatActualValue).join(', ')} }`;
 	}
 	if (value !== null && typeof value === 'object') {
+		if (isIntervalShaped(value)) {
+			const open = value.lowClosed === true ? '[' : '(';
+			const close = value.highClosed === true ? ']' : ')';
+			return `Interval${open}${formatActualValue(value.low)}, ${formatActualValue(value.high)}${close}`;
+		}
+		if (isQuantityShaped(value)) {
+			return `${value.value} '${value.unit}'`;
+		}
 		return JSON.stringify(value);
 	}
 	return String(value);
+}
+
+function isIntervalShaped(value: any): boolean {
+	const keys = Object.keys(value);
+	return (
+		keys.length === 4 &&
+		['lowClosed', 'low', 'highClosed', 'high'].every((key) => keys.includes(key))
+	);
+}
+
+function isQuantityShaped(value: any): boolean {
+	const keys = Object.keys(value);
+	return (
+		keys.length === 2 &&
+		keys.includes('value') &&
+		keys.includes('unit') &&
+		typeof value.unit === 'string'
+	);
 }
 
 /**

--- a/test/cql-test-results-validator.test.ts
+++ b/test/cql-test-results-validator.test.ts
@@ -192,4 +192,87 @@ describe('CQLTestResults.toJSON actual serialization', () => {
     const json = results.toJSON();
     expect(json.results[0].actual).toBe('{ { 1, 2 }, {} }');
   });
+
+  it('renders interval actuals in CQL interval syntax', () => {
+    const results = new CQLTestResults(new CQLEngine('http://localhost:8080/fhir/$cql'));
+    results.add({
+      testsName: 'CqlIntervalOperatorsTest',
+      groupName: 'Interval',
+      testName: 'TimeIntervalTest',
+      expression: 'Interval[@T00:00:00.000, @T23:59:59.599]',
+      testStatus: 'pass',
+      invalid: 'false',
+      actual: {
+        lowClosed: true,
+        low: '@T00:00:00.000',
+        highClosed: true,
+        high: '@T23:59:59.599',
+      },
+      expected: 'Interval[@T00:00:00.000, @T23:59:59.599]',
+    } as any);
+    results.add({
+      testsName: 'T',
+      groupName: 'G',
+      testName: 'OpenHigh',
+      expression: 'e',
+      testStatus: 'pass',
+      invalid: 'false',
+      actual: { lowClosed: true, low: 1, highClosed: false, high: null },
+      expected: 'Interval[1, null)',
+    } as any);
+
+    const json = results.toJSON();
+    expect(json.results[0].actual).toBe('Interval[@T00:00:00.000, @T23:59:59.599]');
+    expect(json.results[1].actual).toBe('Interval[1, null)');
+  });
+
+  it('renders quantity actuals in CQL quantity syntax, standalone and as boundaries', () => {
+    const results = new CQLTestResults(new CQLEngine('http://localhost:8080/fhir/$cql'));
+    results.add({
+      testsName: 'CqlArithmeticFunctionsTest',
+      groupName: 'Multiply',
+      testName: 'Multiply1CMBy2CM',
+      expression: "1.0 'cm' * 2.0 'cm'",
+      testStatus: 'fail',
+      invalid: 'false',
+      actual: { value: 0.0002, unit: 'm2' },
+      expected: "2.0'cm2'",
+    } as any);
+    results.add({
+      testsName: 'T',
+      groupName: 'G',
+      testName: 'QuantityInterval',
+      expression: 'e',
+      testStatus: 'pass',
+      invalid: 'false',
+      actual: {
+        lowClosed: true,
+        low: { value: 1, unit: 'ml' },
+        highClosed: true,
+        high: { value: 2, unit: 'ml' },
+      },
+      expected: "Interval[1 'ml', 2 'ml']",
+    } as any);
+
+    const json = results.toJSON();
+    expect(json.results[0].actual).toBe("0.0002 'm2'");
+    expect(json.results[1].actual).toBe("Interval[1 'ml', 2 'ml']");
+  });
+
+  it('keeps JSON rendering for objects that are not intervals or quantities', () => {
+    const results = new CQLTestResults(new CQLEngine('http://localhost:8080/fhir/$cql'));
+    results.add({
+      testsName: 'T',
+      groupName: 'G',
+      testName: 'Tuple',
+      expression: 'e',
+      testStatus: 'pass',
+      invalid: 'false',
+      actual: { value: 1, unit: null },
+      expected: 'Tuple { value: 1, unit: null }',
+    } as any);
+
+    const json = results.toJSON();
+    expect(json.results[0].actual).toBe('{"value":1,"unit":null}');
+  });
 });

--- a/test/extractResults-cql_operations.test.ts
+++ b/test/extractResults-cql_operations.test.ts
@@ -365,6 +365,120 @@ test('period datetime response check', () => {
 	});
 });
 
+// FHIR Period boundaries are dateTimes, so an Interval<System.Time> arrives with its
+// times anchored to a placeholder date; the cqf-cqlType extension identifies the real
+// point type and the date anchor is stripped back off.
+test('period with Interval<System.Time> cqlType yields time literals', () => {
+	expect(
+		extractor!.extract({
+			resourceType: 'Parameters',
+			parameter: [
+				{
+					name: 'return',
+					extension: [
+						{
+							url: 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType',
+							valueString: 'Interval<System.Time>',
+						},
+					],
+					valuePeriod: {
+						start: '0001-01-01T00:00:00.000',
+						end: '0001-01-01T23:59:59.599',
+					},
+				},
+			],
+		})
+	).toStrictEqual({
+		lowClosed: true,
+		low: '@T00:00:00.000',
+		highClosed: true,
+		high: '@T23:59:59.599',
+	});
+});
+
+test('time interval cqlType matches without the System prefix and strips offsets', () => {
+	expect(
+		extractor!.extract({
+			resourceType: 'Parameters',
+			parameter: [
+				{
+					name: 'return',
+					extension: [
+						{
+							url: 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType',
+							valueString: 'Interval<Time>',
+						},
+					],
+					valuePeriod: {
+						start: '0001-01-01T00:00:00.000+00:00',
+						end: '0001-01-01T23:59:59.599Z',
+					},
+				},
+			],
+		})
+	).toStrictEqual({
+		lowClosed: true,
+		low: '@T00:00:00.000',
+		highClosed: true,
+		high: '@T23:59:59.599',
+	});
+});
+
+test('time interval with a missing boundary keeps the null/closed handling', () => {
+	expect(
+		extractor!.extract({
+			resourceType: 'Parameters',
+			parameter: [
+				{
+					name: 'return',
+					extension: [
+						{
+							url: 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType',
+							valueString: 'Interval<System.Time>',
+						},
+					],
+					valuePeriod: {
+						end: '0001-01-01T23:59:59.599',
+					},
+				},
+			],
+		})
+	).toStrictEqual({
+		lowClosed: false,
+		low: null,
+		highClosed: true,
+		high: '@T23:59:59.599',
+	});
+});
+
+test('period with a non-time cqlType still yields datetime literals', () => {
+	expect(
+		extractor!.extract({
+			resourceType: 'Parameters',
+			parameter: [
+				{
+					name: 'return',
+					extension: [
+						{
+							url: 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType',
+							valueString: 'Interval<System.DateTime>',
+						},
+					],
+					valuePeriod: {
+						start: '2025-01-01T00:00:00-05:00',
+						end: '2025-12-31T00:00:00-05:00',
+					},
+				},
+			],
+		})
+	).toStrictEqual({
+		lowClosed: true,
+		low: '@2025-01-01T00:00:00-05:00',
+		highClosed: true,
+		high: '@2025-12-31T00:00:00-05:00',
+	});
+});
+
 test('code response check', () => {
 	expect(
 		extractor!.extract({

--- a/test/extractResults-cql_operations.test.ts
+++ b/test/extractResults-cql_operations.test.ts
@@ -451,6 +451,95 @@ test('time interval with a missing boundary keeps the null/closed handling', () 
 	});
 });
 
+// A date interval's Period boundaries are date strings (or dateTimes with an anchored
+// time part); without the cqf-cqlType extension they would be formatted as DateTime
+// literals (@2018-01-01T), which never match expected Date literals (@2018-01-01).
+test('period with Interval<System.Date> cqlType yields date literals', () => {
+	expect(
+		extractor!.extract({
+			resourceType: 'Parameters',
+			parameter: [
+				{
+					name: 'return',
+					extension: [
+						{
+							url: 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType',
+							valueString: 'Interval<System.Date>',
+						},
+					],
+					valuePeriod: {
+						start: '2018-01-01',
+						end: '2018-01-04',
+					},
+				},
+			],
+		})
+	).toStrictEqual({
+		lowClosed: true,
+		low: '@2018-01-01',
+		highClosed: true,
+		high: '@2018-01-04',
+	});
+});
+
+test('date interval strips an anchored time part from Period boundaries', () => {
+	expect(
+		extractor!.extract({
+			resourceType: 'Parameters',
+			parameter: [
+				{
+					name: 'return',
+					extension: [
+						{
+							url: 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType',
+							valueString: 'Interval<Date>',
+						},
+					],
+					valuePeriod: {
+						start: '2018-01-01T00:00:00.000',
+						end: '2018-01-04T00:00:00.000',
+					},
+				},
+			],
+		})
+	).toStrictEqual({
+		lowClosed: true,
+		low: '@2018-01-01',
+		highClosed: true,
+		high: '@2018-01-04',
+	});
+});
+
+test('list of date intervals (ExpandPerDay) yields date-literal boundaries', () => {
+	const dateInterval = (start: string, end: string) => ({
+		name: 'return',
+		extension: [
+			{
+				url: 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType',
+				valueString: 'Interval<System.Date>',
+			},
+		],
+		valuePeriod: { start: start, end: end },
+	});
+
+	expect(
+		extractor!.extract({
+			resourceType: 'Parameters',
+			parameter: [
+				dateInterval('2018-01-01', '2018-01-01'),
+				dateInterval('2018-01-02', '2018-01-02'),
+				dateInterval('2018-01-03', '2018-01-03'),
+				dateInterval('2018-01-04', '2018-01-04'),
+			],
+		})
+	).toStrictEqual([
+		{ lowClosed: true, low: '@2018-01-01', highClosed: true, high: '@2018-01-01' },
+		{ lowClosed: true, low: '@2018-01-02', highClosed: true, high: '@2018-01-02' },
+		{ lowClosed: true, low: '@2018-01-03', highClosed: true, high: '@2018-01-03' },
+		{ lowClosed: true, low: '@2018-01-04', highClosed: true, high: '@2018-01-04' },
+	]);
+});
+
 test('period with a non-time cqlType still yields datetime literals', () => {
 	expect(
 		extractor!.extract({


### PR DESCRIPTION
## Problem

Temporal intervals whose point type is not DateTime always failed comparison. FHIR `Period` boundaries are dateTimes, so engines serialize `Interval<System.Time>` and `Interval<System.Date>` as Periods and declare the real point type in the `cqf-cqlType` extension:

```json
{
  "extension": [{ "url": ".../cqf-cqlType", "valueString": "Interval<System.Time>" }],
  "valuePeriod": { "start": "0001-01-01T00:00:00.000", "end": "0001-01-01T23:59:59.599" }
}
```

`DateTimeIntervalExtractor` ignored the extension (a long-standing `TODO`) and formatted every boundary as a DateTime literal:

- Time intervals kept their placeholder date anchor: `@0001-01-01T00:00:00.000` never matches the expected `@T00:00:00.000` (e.g. `CqlIntervalOperatorsTest / Interval / TimeIntervalTest`).
- Date intervals got a trailing `T` appended: `@2018-01-01T` never matches the expected `@2018-01-01` (e.g. `CqlIntervalOperatorsTest / Expand / ExpandPerDay`).

## Changes

- **`DateTimeIntervalExtractor` dispatches on `cqf-cqlType`**: the declared point type (`Date`, `DateTime` or `Time`; `System.` prefix optional, `DateTime` when absent) picks the boundary formatter. Time boundaries drop the date anchor and any timezone offset (a CQL Time carries neither) and become `@T…` literals; Date boundaries keep the `@date` form (no trailing `T`) and drop any anchored time part. Periods without the extension behave exactly as before.
- **`actual` values render in CQL syntax in the results file**: interval-shaped actuals now serialize as `Interval[@T00:00:00.000, @T23:59:59.599]` (brackets/parens per closed flag, recursing into boundaries) and `{value, unit}` quantities as `0.0002 'm2'`, instead of raw JSON — mirroring the expected value's CQL/CVL notation, following the precedent set for lists in #107. Other objects keep the JSON rendering.

## Verification

- End-to-end checks of both reported payloads: the `TimeIntervalTest` Period now extracts to `{low: '@T00:00:00.000', high: '@T23:59:59.599', …}` and the `ExpandPerDay` list of four date Periods extracts to `Interval[@2018-01-01, @2018-01-01] …` boundaries; `resultsEqual` against the cvl-parsed expected values returns true for both.
- New unit tests for the extractor (Time and Date intervals, with/without the `System.` prefix, offset and time-part stripping, missing boundary, extension-less and DateTime-typed Periods unchanged, list of date intervals) and for the results-file rendering (intervals, quantities, quantity-boundary intervals, non-interval objects unchanged). Full suite: 139 passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qw9VWh3fvEPFMArBxnxtXF