### PR TITLE
Support library-style tests

### DIFF
--- a/assets/schema/cql-test-configuration.schema.json
+++ b/assets/schema/cql-test-configuration.schema.json
@@ -20,7 +20,8 @@
         },
         "CqlOperation": {
           "type": "string",
-          "description": "CQL operation endpoint",
+          "enum": ["$cql", "$evaluate"],
+          "description": "CQL operation used to evaluate tests: the system-level $cql operation, or Library/$evaluate",
           "default": "$cql"
         }
       },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "test:cql": "node --import tsx src/bin/cql-tests.ts run-tests conf/localhost.json ./results",
         "cql-run-tests:dev": "tsx src/bin/cql-tests.ts run-tests conf/development.json ./results",
 	    "cql-run-tests:local": "tsx src/bin/cql-tests.ts run-tests conf/localhost.json ./local_results",
+    "cql-run-tests:local-evaluate": "tsx src/bin/cql-tests.ts run-tests conf/localhost-evaluate.json ./local_results",
         "build-libs": "npm run build && node dist/bin/cql-tests.js build-cql conf/localhost.json ./cql",
         "unit-tests": "vitest run test/",
         "clean": "rm -rf dist",

--- a/src/commands/build-cql-command.ts
+++ b/src/commands/build-cql-command.ts
@@ -43,8 +43,9 @@ export class BuildCommand {
 				testsName = r.testsName;
 			}
 
-			// Library-style tests carry their own complete CQL library and are evaluated inline
-			// (via the $cql `content` parameter), so they are not wrapped as a define here.
+			// Library-style tests carry their own complete CQL library and are sent to
+			// Library/$evaluate as an inline FHIR Library resource, so they are neither wrapped
+			// as a define here nor part of the generated library.
 			if (r.library !== undefined) {
 				continue;
 			}

--- a/src/commands/build-cql-command.ts
+++ b/src/commands/build-cql-command.ts
@@ -43,6 +43,12 @@ export class BuildCommand {
 				testsName = r.testsName;
 			}
 
+			// Library-style tests carry their own complete CQL library and are evaluated inline
+			// (via the $cql `content` parameter), so they are not wrapped as a define here.
+			if (r.library !== undefined) {
+				continue;
+			}
+
 			if (r.invalid !== 'semantic') {
 				const defineVal = `define "${r.groupName}.${r.testName}": ${r.expression}`;
 				const key = `${r.testsName}-${r.groupName}-${r.testName}`;

--- a/src/models/test-types.ts
+++ b/src/models/test-types.ts
@@ -88,8 +88,9 @@ export interface InternalTestResult {
 	testVersionTo?: string;
 	invalid?: 'false' | 'true' | 'semantic' | 'undefined';
 	expression: string;
-	// For library-style tests: the full CQL library source that is evaluated inline.
-	// (For these tests, `expression` holds the name of the define whose result is compared.)
+	// For library-style tests: the full CQL library source, sent to Library/$evaluate wrapped as
+	// a FHIR Library resource. (For these tests, `expression` holds the name of the define whose
+	// result is compared.)
 	library?: string;
 	capability?: CapabilityKV[];
 	SkipMessage?: string;

--- a/src/models/test-types.ts
+++ b/src/models/test-types.ts
@@ -3,8 +3,15 @@ export interface TestExpression {
 	invalid: 'false' | 'true' | 'semantic';
 }
 
+export interface TestLibrary {
+	text: string;
+	invalid: 'false' | 'true' | 'semantic';
+}
+
 export interface TestOutput {
 	text: string;
+	// For library-style tests, the name of the define whose result this output describes.
+	name?: string;
 	type?:
 		| 'boolean'
 		| 'code'
@@ -29,7 +36,9 @@ export interface Test {
 	mode?: 'strict' | 'loose';
 	ordered?: boolean;
 	checkOrderedFunctions?: boolean;
-	expression: string | TestExpression;
+	// A test provides EITHER an expression OR a full CQL library (mutually exclusive; see testSchema.xsd).
+	expression?: string | TestExpression;
+	library?: string | TestLibrary;
 	capability: CapabilityKV[];
 	output?: string | TestOutput | string[] | TestOutput[];
 }
@@ -79,6 +88,9 @@ export interface InternalTestResult {
 	testVersionTo?: string;
 	invalid?: 'false' | 'true' | 'semantic' | 'undefined';
 	expression: string;
+	// For library-style tests: the full CQL library source that is evaluated inline.
+	// (For these tests, `expression` holds the name of the define whose result is compared.)
+	library?: string;
 	capability?: CapabilityKV[];
 	SkipMessage?: string;
 }

--- a/src/server/test-execution-service.ts
+++ b/src/server/test-execution-service.ts
@@ -87,6 +87,12 @@ export class TestExecutionService {
       result.SkipMessage = `Skipped by config: ${reason}`;
       result.testStatus = 'skip';
       return result;
+    } else if (result.library !== undefined && config.FhirServer.CqlOperation !== '$evaluate') {
+      // A whole CQL library can only be passed to Library/$evaluate, not to $cql.
+      result.SkipMessage =
+        'Library-style tests require a server configured for the Library/$evaluate operation';
+      result.testStatus = 'skip';
+      return result;
     }
 
     const data = generateParametersResource(result, config.FhirServer.CqlOperation);

--- a/src/server/test-execution-service.ts
+++ b/src/server/test-execution-service.ts
@@ -9,6 +9,7 @@ import {
   generateParametersResource,
   Result,
 } from '../shared/results-shared.js';
+import { PublishedLibrary, publishTestLibrary } from '../shared/library-publisher.js';
 import { InternalTestResult, Tests } from '../models/test-types.js';
 import { ServerConnectivity } from '../shared/server-connectivity.js';
 import { ResultExtractor } from '../extractors/result-extractor.js';
@@ -95,10 +96,23 @@ export class TestExecutionService {
       return result;
     }
 
-    const data = generateParametersResource(result, config.FhirServer.CqlOperation);
+    let publishedLibrary: PublishedLibrary | undefined;
 
     try {
       console.log('Running test %s:%s:%s', result.testsName, result.groupName, result.testName);
+
+      // A library-style test's CQL has to exist on the server before Library/$evaluate can
+      // resolve it; it is removed again once the test has run.
+      if (result.library !== undefined) {
+        publishedLibrary = await publishTestLibrary(config.FhirServer.BaseUrl, result.library);
+      }
+
+      const data = generateParametersResource(
+        result,
+        config.FhirServer.CqlOperation,
+        publishedLibrary?.canonical
+      );
+
       const response = await fetch(apiUrl, {
         method: 'POST',
         headers: {
@@ -131,6 +145,8 @@ export class TestExecutionService {
         name: error.name || 'Error',
         stack: error.stack
       };
+    } finally {
+      await publishedLibrary?.remove();
     }
 
     console.log('Test %s:%s:%s status: %s expected: %s actual: %s',

--- a/src/services/test-runner.ts
+++ b/src/services/test-runner.ts
@@ -146,6 +146,23 @@ export class TestRunner {
 				result.skipMessage
 			);
 			return result;
+		} else if (
+			result.library !== undefined &&
+			config.FhirServer.CqlOperation !== '$evaluate'
+		) {
+			// A whole CQL library can only be passed to Library/$evaluate, not to $cql.
+			result.skipMessage =
+				'Library-style tests require a server configured for the Library/$evaluate operation';
+			result.testStatus = 'skip';
+			console.log(
+				'Test %s:%s:%s status: %s skipMessage: %s',
+				result.testsName,
+				result.groupName,
+				result.testName,
+				result.testStatus,
+				result.skipMessage
+			);
+			return result;
 		}
 		const data = generateParametersResource(result, config.FhirServer.CqlOperation);
 

--- a/src/services/test-runner.ts
+++ b/src/services/test-runner.ts
@@ -3,6 +3,7 @@ import { CQLEngine } from '../cql-engine/cql-engine.js';
 import { TestLoader } from '../loaders/test-loader.js';
 import { CQLTestResults } from '../test-results/cql-test-results.js';
 import { generateEmptyResults, generateParametersResource } from '../shared/results-shared.js';
+import { PublishedLibrary, publishTestLibrary } from '../shared/library-publisher.js';
 import { InternalTestResult } from '../models/test-types.js';
 import { ResultExtractor } from '../extractors/result-extractor.js';
 import { ServerConnectivity } from '../shared/server-connectivity.js';
@@ -164,7 +165,7 @@ export class TestRunner {
 			);
 			return result;
 		}
-		const data = generateParametersResource(result, config.FhirServer.CqlOperation);
+		let publishedLibrary: PublishedLibrary | undefined;
 
 		try {
 			console.log(
@@ -172,6 +173,21 @@ export class TestRunner {
 				result.testsName,
 				result.groupName,
 				result.testName
+			);
+
+			// A library-style test's CQL has to exist on the server before Library/$evaluate can
+			// resolve it; it is removed again once the test has run.
+			if (result.library !== undefined) {
+				publishedLibrary = await publishTestLibrary(
+					config.FhirServer.BaseUrl,
+					result.library
+				);
+			}
+
+			const data = generateParametersResource(
+				result,
+				config.FhirServer.CqlOperation,
+				publishedLibrary?.canonical
 			);
 
 			let response: any;
@@ -228,6 +244,8 @@ export class TestRunner {
 				name: error.name || 'Error',
 				stack: error.stack,
 			};
+		} finally {
+			await publishedLibrary?.remove();
 		}
 
 		console.log(

--- a/src/shared/library-publisher.ts
+++ b/src/shared/library-publisher.ts
@@ -1,0 +1,111 @@
+import { Library } from 'fhir/r4';
+
+/**
+ * A library-style test's CQL, published to the server as a FHIR Library resource so that
+ * Library/$evaluate can resolve it by canonical url.
+ */
+export interface PublishedLibrary {
+	/** Resource id the library was published under. */
+	id: string;
+	/** Value for the `url` parameter of Library/$evaluate (canonical, with version when declared). */
+	canonical: string;
+	/** Removes the published library from the server. Never throws. */
+	remove: () => Promise<void>;
+}
+
+/**
+ * Wraps CQL source as a FHIR Library resource conforming to the CQLLibrary profile in the
+ * Using CQL IG: exactly one `content` element whose contentType starts with `text/cql` (clb-1)
+ * carrying base-64 encoded data (clb-2), with a name of 64 characters or less (clb-3).
+ *
+ * Name and version are read from the library declaration so the resource carries the same
+ * identity the CQL itself declares (engines resolve and cache libraries by name and version).
+ */
+export function buildCqlLibraryResource(cql: string): Library {
+	const source = cql.trim();
+	const declaration =
+		/^library\s+("[^"]+"|[A-Za-z_][A-Za-z0-9_.]*)(?:\s+version\s+'([^']*)')?/m.exec(source);
+
+	if (declaration === null) {
+		throw new Error('Library-style test CQL has no library declaration');
+	}
+
+	const name = declaration[1].replace(/^"|"$/g, '');
+	const version = declaration[2];
+
+	if (name.length > 64) {
+		throw new Error(
+			`Library name '${name}' exceeds the 64 character limit of the CQLLibrary profile`
+		);
+	}
+
+	return {
+		resourceType: 'Library',
+		url: `https://hl7.org/fhir/uv/cql/Library/${name}`,
+		name,
+		...(version !== undefined ? { version } : {}),
+		status: 'active',
+		type: {
+			coding: [
+				{
+					system: 'http://terminology.hl7.org/CodeSystem/library-type',
+					code: 'logic-library',
+				},
+			],
+		},
+		content: [
+			{
+				contentType: 'text/cql',
+				data: Buffer.from(source, 'utf8').toString('base64'),
+			},
+		],
+	};
+}
+
+/** Derives a valid FHIR id ([A-Za-z0-9\-\.]{1,64}) for the library resource. */
+function libraryResourceId(name: string): string {
+	return `cql-tests-${name}`.replace(/[^A-Za-z0-9.-]/g, '-').slice(0, 64);
+}
+
+/**
+ * Publishes a library-style test's CQL to the server so Library/$evaluate can resolve it.
+ *
+ * Library/$evaluate also defines an inline `library` parameter that takes the Library as a
+ * resource, which would avoid this round trip. It is not usable in practice: clinical-reasoning
+ * passes only the resource's canonical to the engine (EvaluateProcessor.evaluate) and discards
+ * the `content` element, so evaluation fails with "Could not load source for library ...".
+ * Publishing first and evaluating by `url` uses the same operation and the same profiled
+ * resource, and works today.
+ */
+export async function publishTestLibrary(baseUrl: string, cql: string): Promise<PublishedLibrary> {
+	const library = buildCqlLibraryResource(cql);
+	const id = libraryResourceId(library.name!);
+	const resourceUrl = `${baseUrl}/Library/${id}`;
+
+	const response = await fetch(resourceUrl, {
+		method: 'PUT',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ ...library, id }),
+	});
+
+	if (response.status !== 200 && response.status !== 201) {
+		const body = await response.text().catch(() => '');
+		throw new Error(
+			`Failed to publish library ${library.name} to ${resourceUrl}: ${response.status} ${body}`.trim()
+		);
+	}
+
+	return {
+		id,
+		canonical:
+			library.version !== undefined ? `${library.url}|${library.version}` : library.url!,
+		remove: async () => {
+			try {
+				await fetch(resourceUrl, { method: 'DELETE' });
+			} catch (error: any) {
+				// Cleanup failures must not change the outcome of the test.
+				console.warn(`Failed to remove published library ${id}: ${error.message}`);
+			}
+		},
+	};
+}

--- a/src/shared/results-shared.ts
+++ b/src/shared/results-shared.ts
@@ -1,5 +1,5 @@
 import { Tests, Test, InternalTestResult, CapabilityKV } from '../models/test-types.js';
-import { Library, Parameters } from 'fhir/r4';
+import { Parameters } from 'fhir/r4';
 
 export class Result implements InternalTestResult {
 	testStatus!: 'pass' | 'fail' | 'skip' | 'error';
@@ -132,66 +132,18 @@ export async function generateEmptyResults(
 	return groupResults;
 }
 
-/**
- * Wraps CQL source as a FHIR Library resource conforming to the CQLLibrary profile in the
- * Using CQL IG, as required by the `library` parameter of Library/$evaluate: exactly one
- * `content` element whose contentType starts with `text/cql` (clb-1) carrying base-64 encoded
- * data (clb-2), with a name of 64 characters or less (clb-3).
- *
- * Name and version are read from the library declaration so the resource carries the same
- * identity the CQL itself declares (engines resolve and cache libraries by name and version).
- */
-export function buildCqlLibraryResource(cql: string): Library {
-	const source = cql.trim();
-	const declaration =
-		/^library\s+("[^"]+"|[A-Za-z_][A-Za-z0-9_.]*)(?:\s+version\s+'([^']*)')?/m.exec(source);
-
-	if (declaration === null) {
-		throw new Error('Library-style test CQL has no library declaration');
-	}
-
-	const name = declaration[1].replace(/^"|"$/g, '');
-	const version = declaration[2];
-
-	if (name.length > 64) {
-		throw new Error(
-			`Library name '${name}' exceeds the 64 character limit of the CQLLibrary profile`
-		);
-	}
-
-	return {
-		resourceType: 'Library',
-		url: `https://hl7.org/fhir/uv/cql/Library/${name}`,
-		name,
-		...(version !== undefined ? { version } : {}),
-		status: 'active',
-		type: {
-			coding: [
-				{
-					system: 'http://terminology.hl7.org/CodeSystem/library-type',
-					code: 'logic-library',
-				},
-			],
-		},
-		content: [
-			{
-				contentType: 'text/cql',
-				data: Buffer.from(source, 'utf8').toString('base64'),
-			},
-		],
-	};
-}
-
 export function generateParametersResource(
 	result: InternalTestResult,
-	cqlEndpoint: string
+	cqlEndpoint: string,
+	libraryCanonical?: string
 ): Parameters {
 	let data: Parameters;
 
-	// Library-style tests carry a complete CQL library, which only Library/$evaluate can accept:
-	// its `library` parameter takes the library as a FHIR resource. The $cql operation has no way
-	// to carry library source — its `library` parameter resolves by canonical url only, and its
-	// `expression` parameter is an expression of CQL, not the text of a library.
+	// Library-style tests carry a complete CQL library, which only Library/$evaluate can accept.
+	// The $cql operation has no way to carry library source — its `library` parameter resolves by
+	// canonical url only, and its `expression` parameter is an expression of CQL, not the text of
+	// a library. The library is published to the server first (see publishTestLibrary) and
+	// referenced here by canonical url.
 	if (result.library !== undefined) {
 		if (cqlEndpoint !== '$evaluate') {
 			throw new Error(
@@ -199,13 +151,18 @@ export function generateParametersResource(
 			);
 		}
 
+		if (libraryCanonical === undefined) {
+			throw new Error(
+				'Library-style tests require the canonical url of the published library'
+			);
+		}
+
 		return {
 			resourceType: 'Parameters',
 			parameter: [
-				// `library` is mutually exclusive with `url`, so no url parameter is sent here.
 				{
-					name: 'library',
-					resource: buildCqlLibraryResource(result.library),
+					name: 'url',
+					valueCanonical: libraryCanonical,
 				},
 				// `expression` (0..*) names the define to evaluate; the response is keyed by that name.
 				{

--- a/src/shared/results-shared.ts
+++ b/src/shared/results-shared.ts
@@ -1,5 +1,5 @@
 import { Tests, Test, InternalTestResult, CapabilityKV } from '../models/test-types.js';
-import { Parameters } from 'fhir/r4';
+import { Library, Parameters } from 'fhir/r4';
 
 export class Result implements InternalTestResult {
 	testStatus!: 'pass' | 'fail' | 'skip' | 'error';
@@ -30,9 +30,9 @@ export class Result implements InternalTestResult {
 		this.testVersionTo = test.versionTo;
 
 		if (test.library !== undefined) {
-			// Library-style test: the whole CQL library is evaluated inline. The value sent as
-			// `expression` is the name of the define to evaluate, taken from the output's `name`
-			// attribute (defaults to 'output').
+			// Library-style test: the whole CQL library is sent to Library/$evaluate as an inline
+			// FHIR Library resource, and `expression` names the define whose result is compared.
+			// The define name comes from the output's `name` attribute (testSchema.xsd).
 			if (typeof test.library === 'string') {
 				this.invalid = 'false';
 				this.library = test.library;
@@ -40,11 +40,26 @@ export class Result implements InternalTestResult {
 				this.invalid = test.library.invalid;
 				this.library = test.library.text;
 			}
-			const out = test.output;
-			this.expression =
-				out !== undefined && typeof out !== 'string' && !Array.isArray(out) && out.name
-					? out.name
-					: 'output';
+
+			this.expression = '';
+			const outputs = Array.isArray(test.output) ? test.output : [test.output];
+			if (outputs.length > 1) {
+				// The schema allows one output per define; the result model holds a single
+				// expected value, so multi-define libraries can't be compared yet.
+				this.testStatus = 'skip';
+				this.skipMessage =
+					'Library-style tests with more than one named output are not yet supported';
+			} else {
+				const out = outputs[0];
+				const defineName = typeof out === 'object' ? out.name : undefined;
+				if (defineName) {
+					this.expression = defineName;
+				} else {
+					this.testStatus = 'skip';
+					this.skipMessage =
+						"Library-style test output has no 'name' attribute naming the define to evaluate";
+				}
+			}
 		} else if (typeof test.expression !== 'string') {
 			if (test.expression === undefined) {
 				this.invalid = 'undefined';
@@ -117,11 +132,89 @@ export async function generateEmptyResults(
 	return groupResults;
 }
 
+/**
+ * Wraps CQL source as a FHIR Library resource conforming to the CQLLibrary profile in the
+ * Using CQL IG, as required by the `library` parameter of Library/$evaluate: exactly one
+ * `content` element whose contentType starts with `text/cql` (clb-1) carrying base-64 encoded
+ * data (clb-2), with a name of 64 characters or less (clb-3).
+ *
+ * Name and version are read from the library declaration so the resource carries the same
+ * identity the CQL itself declares (engines resolve and cache libraries by name and version).
+ */
+export function buildCqlLibraryResource(cql: string): Library {
+	const source = cql.trim();
+	const declaration =
+		/^library\s+("[^"]+"|[A-Za-z_][A-Za-z0-9_.]*)(?:\s+version\s+'([^']*)')?/m.exec(source);
+
+	if (declaration === null) {
+		throw new Error('Library-style test CQL has no library declaration');
+	}
+
+	const name = declaration[1].replace(/^"|"$/g, '');
+	const version = declaration[2];
+
+	if (name.length > 64) {
+		throw new Error(
+			`Library name '${name}' exceeds the 64 character limit of the CQLLibrary profile`
+		);
+	}
+
+	return {
+		resourceType: 'Library',
+		url: `https://hl7.org/fhir/uv/cql/Library/${name}`,
+		name,
+		...(version !== undefined ? { version } : {}),
+		status: 'active',
+		type: {
+			coding: [
+				{
+					system: 'http://terminology.hl7.org/CodeSystem/library-type',
+					code: 'logic-library',
+				},
+			],
+		},
+		content: [
+			{
+				contentType: 'text/cql',
+				data: Buffer.from(source, 'utf8').toString('base64'),
+			},
+		],
+	};
+}
+
 export function generateParametersResource(
 	result: InternalTestResult,
 	cqlEndpoint: string
 ): Parameters {
 	let data: Parameters;
+
+	// Library-style tests carry a complete CQL library, which only Library/$evaluate can accept:
+	// its `library` parameter takes the library as a FHIR resource. The $cql operation has no way
+	// to carry library source — its `library` parameter resolves by canonical url only, and its
+	// `expression` parameter is an expression of CQL, not the text of a library.
+	if (result.library !== undefined) {
+		if (cqlEndpoint !== '$evaluate') {
+			throw new Error(
+				`Library-style tests require the Library/$evaluate operation; configured operation is ${cqlEndpoint}`
+			);
+		}
+
+		return {
+			resourceType: 'Parameters',
+			parameter: [
+				// `library` is mutually exclusive with `url`, so no url parameter is sent here.
+				{
+					name: 'library',
+					resource: buildCqlLibraryResource(result.library),
+				},
+				// `expression` (0..*) names the define to evaluate; the response is keyed by that name.
+				{
+					name: 'expression',
+					valueString: result.expression,
+				},
+			],
+		};
+	}
 
 	// Check if the last part is $cql or $evaluate
 	if (cqlEndpoint === '$cql') {
@@ -134,14 +227,6 @@ export function generateParametersResource(
 				},
 			],
 		};
-		// Library-style tests: pass the full CQL library inline via the `content` parameter.
-		// `expression` then names the define within that library to evaluate.
-		if (result.library !== undefined) {
-			data.parameter!.push({
-				name: 'content',
-				valueString: result.library,
-			});
-		}
 	} else if (cqlEndpoint === '$evaluate') {
 		data = {
 			resourceType: 'Parameters',

--- a/src/shared/results-shared.ts
+++ b/src/shared/results-shared.ts
@@ -19,6 +19,7 @@ export class Result implements InternalTestResult {
 	testVersionTo?: string;
 	invalid: 'false' | 'true' | 'semantic' | 'undefined';
 	expression: string;
+	library?: string;
 	capability: CapabilityKV[] = [];
 
 	constructor(testsName: string, groupName: string, test: Test) {
@@ -28,7 +29,23 @@ export class Result implements InternalTestResult {
 		this.testVersion = test.version;
 		this.testVersionTo = test.versionTo;
 
-		if (typeof test.expression !== 'string') {
+		if (test.library !== undefined) {
+			// Library-style test: the whole CQL library is evaluated inline. The value sent as
+			// `expression` is the name of the define to evaluate, taken from the output's `name`
+			// attribute (defaults to 'output').
+			if (typeof test.library === 'string') {
+				this.invalid = 'false';
+				this.library = test.library;
+			} else {
+				this.invalid = test.library.invalid;
+				this.library = test.library.text;
+			}
+			const out = test.output;
+			this.expression =
+				out !== undefined && typeof out !== 'string' && !Array.isArray(out) && out.name
+					? out.name
+					: 'output';
+		} else if (typeof test.expression !== 'string') {
 			if (test.expression === undefined) {
 				this.invalid = 'undefined';
 				this.expression = 'undefined';
@@ -117,6 +134,14 @@ export function generateParametersResource(
 				},
 			],
 		};
+		// Library-style tests: pass the full CQL library inline via the `content` parameter.
+		// `expression` then names the define within that library to evaluate.
+		if (result.library !== undefined) {
+			data.parameter!.push({
+				name: 'content',
+				valueString: result.library,
+			});
+		}
 	} else if (cqlEndpoint === '$evaluate') {
 		data = {
 			resourceType: 'Parameters',

--- a/test/library-style-tests.test.ts
+++ b/test/library-style-tests.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, test, vi, Mock } from 'vitest';
+
+import { Result, generateParametersResource } from '../src/shared/results-shared.js';
+import { buildCqlLibraryResource, publishTestLibrary } from '../src/shared/library-publisher.js';
+import { Test } from '../src/models/test-types.js';
+
+// The shape produced by the XML loader for the library-style test in cqframework/cql-tests#61.
+const libraryCql = `library SimpleOverloadMatching version '1.0.0'
+
+define function A(foo Decimal): 'DecimalOverload'
+define function A(foo Integer): 'IntegerOverload'
+
+define output: A(1.0)`;
+
+// libraryCql, base-64 encoded (clb-2). Pinned as a literal so the test does not depend on
+// Node globals, which the test directory has no type coverage for.
+const libraryCqlBase64 =
+	'bGlicmFyeSBTaW1wbGVPdmVybG9hZE1hdGNoaW5nIHZlcnNpb24gJzEuMC4wJwoKZGVmaW5lIGZ1bmN0aW9uIEEoZm9vIERlY2ltYWwpOiAnRGVjaW1hbE92ZXJsb2FkJwpkZWZpbmUgZnVuY3Rpb24gQShmb28gSW50ZWdlcik6ICdJbnRlZ2VyT3ZlcmxvYWQnCgpkZWZpbmUgb3V0cHV0OiBBKDEuMCk=';
+
+const canonical = 'https://hl7.org/fhir/uv/cql/Library/SimpleOverloadMatching|1.0.0';
+
+const libraryTest = (over: Partial<Test> = {}): Test =>
+	({
+		name: 'SimpleOverloadMatching',
+		library: libraryCql,
+		output: { name: 'output', text: "'DecimalOverload'" },
+		capability: [],
+		...over,
+	}) as Test;
+
+describe('library-style test results', () => {
+	test('evaluates the define named by the output', () => {
+		const result = new Result('OverloadMatching', 'OverloadMatching', libraryTest());
+
+		expect(result.library).toBe(libraryCql);
+		expect(result.expression).toBe('output');
+		expect(result.expected).toBe("'DecimalOverload'");
+		expect(result.invalid).toBe('false');
+		expect(result.testStatus).toBeUndefined();
+	});
+
+	test('carries the invalid attribute from the library element', () => {
+		const result = new Result(
+			'OverloadMatching',
+			'OverloadMatching',
+			libraryTest({ library: { text: libraryCql, invalid: 'semantic' } })
+		);
+
+		expect(result.invalid).toBe('semantic');
+		expect(result.library).toBe(libraryCql);
+	});
+
+	test('skips when the output does not name a define', () => {
+		const result = new Result(
+			'OverloadMatching',
+			'OverloadMatching',
+			libraryTest({ output: "'DecimalOverload'" })
+		);
+
+		expect(result.testStatus).toBe('skip');
+		expect(result.skipMessage).toMatch(/no 'name' attribute/);
+	});
+
+	test('skips library tests with more than one named output', () => {
+		const result = new Result(
+			'OverloadMatching',
+			'OverloadMatching',
+			libraryTest({
+				output: [
+					{ name: 'output', text: "'DecimalOverload'" },
+					{ name: 'other', text: "'IntegerOverload'" },
+				],
+			})
+		);
+
+		expect(result.testStatus).toBe('skip');
+		expect(result.skipMessage).toMatch(/more than one named output/);
+	});
+});
+
+describe('CQLLibrary resource', () => {
+	test('wraps the CQL as a CQLLibrary-conformant resource', () => {
+		const library = buildCqlLibraryResource(libraryCql) as any;
+
+		expect(library.resourceType).toBe('Library');
+		expect(library.url).toBe('https://hl7.org/fhir/uv/cql/Library/SimpleOverloadMatching');
+		expect(library.name).toBe('SimpleOverloadMatching');
+		expect(library.version).toBe('1.0.0');
+		expect(library.status).toBe('active');
+		expect(library.type.coding[0]).toEqual({
+			system: 'http://terminology.hl7.org/CodeSystem/library-type',
+			code: 'logic-library',
+		});
+
+		// clb-1: exactly one content element starting with text/cql. clb-2: base-64 data.
+		expect(library.content).toHaveLength(1);
+		expect(library.content[0].contentType).toBe('text/cql');
+		expect(library.content[0].data).toBe(libraryCqlBase64);
+	});
+
+	test('omits version when the library declaration has none', () => {
+		const library = buildCqlLibraryResource('library NoVersion\n\ndefine output: 1') as any;
+
+		expect(library.name).toBe('NoVersion');
+		expect(library.version).toBeUndefined();
+	});
+
+	test('rejects CQL with no library declaration', () => {
+		expect(() => buildCqlLibraryResource('define output: 1 + 1')).toThrow(
+			/no library declaration/
+		);
+	});
+
+	test('rejects a library name longer than the profile allows', () => {
+		const tooLong = 'A'.repeat(65);
+
+		expect(() => buildCqlLibraryResource(`library ${tooLong}\n\ndefine output: 1`)).toThrow(
+			/64 character limit/
+		);
+	});
+});
+
+describe('publishing a library-style test', () => {
+	let fetchSpy: Mock;
+
+	beforeEach(() => {
+		fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+			status: 201,
+			text: () => Promise.resolve(''),
+		} as Response);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test('PUTs the library and reports its canonical url', async () => {
+		const published = await publishTestLibrary('http://localhost:8080/fhir', libraryCql);
+
+		expect(published.id).toBe('cql-tests-SimpleOverloadMatching');
+		expect(published.canonical).toBe(canonical);
+
+		const [url, init] = fetchSpy.mock.calls[0];
+		expect(url).toBe('http://localhost:8080/fhir/Library/cql-tests-SimpleOverloadMatching');
+		expect(init.method).toBe('PUT');
+		const body = JSON.parse(init.body);
+		expect(body.resourceType).toBe('Library');
+		expect(body.id).toBe('cql-tests-SimpleOverloadMatching');
+		expect(body.content[0].data).toBe(libraryCqlBase64);
+	});
+
+	test('removes the published library again', async () => {
+		const published = await publishTestLibrary('http://localhost:8080/fhir', libraryCql);
+		await published.remove();
+
+		const [url, init] = fetchSpy.mock.calls[1];
+		expect(url).toBe('http://localhost:8080/fhir/Library/cql-tests-SimpleOverloadMatching');
+		expect(init.method).toBe('DELETE');
+	});
+
+	test('reports a failed publish', async () => {
+		fetchSpy.mockResolvedValue({
+			status: 422,
+			text: () => Promise.resolve('unprocessable'),
+		} as Response);
+
+		await expect(publishTestLibrary('http://localhost:8080/fhir', libraryCql)).rejects.toThrow(
+			/Failed to publish library SimpleOverloadMatching.*422 unprocessable/
+		);
+	});
+
+	test('a failed removal does not throw', async () => {
+		const published = await publishTestLibrary('http://localhost:8080/fhir', libraryCql);
+		fetchSpy.mockRejectedValue(new Error('connection reset'));
+
+		await expect(published.remove()).resolves.toBeUndefined();
+	});
+});
+
+describe('Library/$evaluate parameters', () => {
+	test('references the published library by canonical url', () => {
+		const result = new Result('OverloadMatching', 'OverloadMatching', libraryTest());
+		const parameters = generateParametersResource(result, '$evaluate', canonical);
+
+		expect(parameters.parameter!.map(p => p.name)).toEqual(['url', 'expression']);
+		expect(parameters.parameter![0].valueCanonical).toBe(canonical);
+		expect(parameters.parameter![1].valueString).toBe('output');
+	});
+
+	test('refuses to send a library test to the $cql operation', () => {
+		const result = new Result('OverloadMatching', 'OverloadMatching', libraryTest());
+
+		expect(() => generateParametersResource(result, '$cql', canonical)).toThrow(
+			/require the Library\/\$evaluate operation/
+		);
+	});
+
+	test('requires the library to have been published', () => {
+		const result = new Result('OverloadMatching', 'OverloadMatching', libraryTest());
+
+		expect(() => generateParametersResource(result, '$evaluate')).toThrow(
+			/canonical url of the published library/
+		);
+	});
+});

--- a/test/run-tests.test.ts
+++ b/test/run-tests.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import { TestRunner } from '../src/services/test-runner.js';
 import * as ResultsUtils from '../src/shared/results-utils.js';
+import * as ResultsShared from '../src/shared/results-shared.js';
 
 vi.mock('../src/loaders/test-loader', () => ({
   TestLoader: { load: vi.fn().mockReturnValue([]) },
@@ -348,5 +349,84 @@ describe('RunTests filtering (TestRunner)', () => {
       failCount: 0,
       errorCount: 0,
     });
+  });
+});
+
+describe('Library-style tests (TestRunner)', () => {
+  let runner: TestRunner;
+  let fetchSpy: Mock;
+
+  const libraryResult = () => ({
+    testsName: 'OverloadMatching',
+    groupName: 'OverloadMatching',
+    testName: 'SimpleOverloadMatching',
+    // For library-style tests `expression` is the name of the define to evaluate.
+    expression: 'output',
+    library: "library SimpleOverloadMatching version '1.0.0'\n\ndefine output: 'DecimalOverload'",
+    expected: "'DecimalOverload'",
+    invalid: 'false',
+    capability: [],
+  });
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({}),
+    } as Response);
+    vi.spyOn(ResultsUtils, 'resultsEqual').mockReturnValue(true);
+    vi.mocked(ResultsShared.generateEmptyResults).mockImplementationOnce(async () => [
+      [libraryResult()],
+    ]);
+    vi.mocked(ResultsShared.generateParametersResource).mockClear();
+    runner = new TestRunner();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('skips a library-style test when the server is configured for $cql', async () => {
+    const results = await runner.runTests(
+      { ...baseConfig, FhirServer: { ...baseConfig.FhirServer, CqlOperation: '$cql' } },
+      { useAxios: false }
+    );
+
+    const test = results.results[0];
+    expect(test.testStatus).toBe('skip');
+    expect(test.skipMessage).toMatch(/Library\/\$evaluate/);
+    // The library is never sent to an operation that cannot carry it.
+    expect(ResultsShared.generateParametersResource).not.toHaveBeenCalled();
+    // Only the server connectivity check should have hit the network.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(results.toJSON().testResultsSummary).toEqual({
+      passCount: 0,
+      skipCount: 1,
+      failCount: 0,
+      errorCount: 0,
+    });
+  });
+
+  it('runs a library-style test when the server is configured for $evaluate', async () => {
+    const results = await runner.runTests(
+      { ...baseConfig, FhirServer: { ...baseConfig.FhirServer, CqlOperation: '$evaluate' } },
+      { useAxios: false }
+    );
+
+    expect(results.results[0].testStatus).toBe('pass');
+    expect(ResultsShared.generateParametersResource).toHaveBeenCalledTimes(1);
+    expect(ResultsShared.generateParametersResource).toHaveBeenCalledWith(
+      expect.objectContaining({ expression: 'output' }),
+      '$evaluate',
+      'https://hl7.org/fhir/uv/cql/Library/SimpleOverloadMatching|1.0.0'
+    );
+
+    // The library is published before evaluation and removed afterwards.
+    const requests = fetchSpy.mock.calls.map(([url, init]: any[]) => `${init?.method ?? 'GET'} ${url}`);
+    expect(requests).toContain(
+      'PUT http://localhost:8080/fhir/Library/cql-tests-SimpleOverloadMatching'
+    );
+    expect(requests).toContain(
+      'DELETE http://localhost:8080/fhir/Library/cql-tests-SimpleOverloadMatching'
+    );
   });
 });


### PR DESCRIPTION
## Summary
Adds runner support for tests that provide a full CQL `<library>` and a named
`<output>`, complementing the schema change in cqframework/cql-tests#141.
Enables cqframework/cql-tests#61 to actually execute, and is the runner side of
cqframework/cql-tests#17.

## Changes
- `models/test-types.ts`: add `TestLibrary`; make `expression` optional; add
  `library` and `TestOutput.name`.
- `shared/results-shared.ts`: build a `Result` from a library test (evaluates the
  define named by `<output name>`, defaulting to `output`) and pass the library
  inline via the `$cql` `content` parameter.
- `commands/build-cql-command.ts`: skip library tests (they are evaluated inline,
  not wrapped as generated `define` statements).

## Wire format
The cqframework `$cql` operation accepts the whole library as a top-level
`content` (string) parameter plus `expression` = the **unqualified** define name;
it returns the result keyed by that define name. (HL7 base `$cql` only references
libraries by URL; this uses the cqframework inline-`content` extension.)

## ⚠️ Authoring note (engine caching)
The engine caches inline libraries by `name` + `version`, so **every
library-style test must declare a unique `library` name** or a stale compiled
copy is returned. Discovered while validating; flagging for test authors. A
future hardening could auto-uniquify the name/version per test.

## Validation
`tsc --noEmit` clean; ran the runner against #61's file →
`SimpleOverloadMatching status: pass`.

## Relationship to other work
- Schema counterpart: cqframework/cql-tests#141
- Part of cqframework/cql-tests#17
- Enables cqframework/cql-tests#61