### PR TITLE
Allow overriding the test directory via CQL_TESTS_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,13 @@ You can still override specific settings using environment variables:
 ```sh
 export SERVER_BASE_URL=http://fhirServerBaseEndpoint
 export CQL_OPERATION=$cql
+export CQL_TESTS_PATH=cql-tests/tests/cql
 ```
+
+`CQL_TESTS_PATH` sets the directory the test loader reads test XML from, defaulting to
+`cql-tests/tests/cql`. Point it at another directory in the `cql-tests` submodule — for
+example `cql-tests/tests/connectathonTests` — to run a different suite without editing a
+configuration file.
 
 ### Development Environment
 

--- a/src/loaders/test-loader.ts
+++ b/src/loaders/test-loader.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { XMLParser, type X2jOptions } from 'fast-xml-parser';
 import { Tests } from '../models/test-types.js';
 
-const testsPath = 'cql-tests/tests/cql';
+const testsPath = process.env.CQL_TESTS_PATH || 'cql-tests/tests/cql';
 
 const alwaysArray = ['tests.group', 'tests.group.test'];
 


### PR DESCRIPTION
TestLoader's path was hardcoded to cql-tests/tests/cql. Read an optional CQL_TESTS_PATH env var (falling back to the default) so different suites — e.g. connectathonTests vs mainTests — can be run without editing source.


---

Moved from #104, which was raised from a fork before I had committer access on this repository. Same work, same branch name, now hosted here so CI and reviews run against `cqframework` directly.
