### PR TITLE
Formatting fixes for display

### DIFF
--- a/src/services/test-runner.ts
+++ b/src/services/test-runner.ts
@@ -220,7 +220,7 @@ export class TestRunner {
 			result.testName,
 			result.testStatus,
 			result.expected,
-			result.actual
+			CQLTestResults.formatActualValue(result.actual)
 		);
 
 		return result;

--- a/src/test-results/cql-test-results.ts
+++ b/src/test-results/cql-test-results.ts
@@ -6,14 +6,14 @@ import { TestResultsSummary, CQLTestResultsData } from '../models/results-types.
 import { ResultsValidator } from '../conf/results-validator.js';
 
 /**
- * Formats an actual value for the results file and for console output. Lists
- * (`{ a, b, c }`), intervals (`Interval[low, high)`) and quantities (`2.0 'cm2'`)
- * are rendered in CQL syntax so they read like the expected value, which is kept
- * in its original CQL/CVL notation.
+ * Formats an actual value for report output. Structured CQL values are rendered in
+ * CQL syntax so they read like the expected value, which is kept in its original
+ * CQL/CVL notation; anything else falls back to JSON, since String(object) yields
+ * "[object Object]" and loses the structure entirely.
  *
- * Values are reported exactly as the engine returned them. In particular, a
- * DateTime at midnight with an offset (`@2018-01-01T00:00:00-07:00`) is never
- * collapsed to Date precision — that would change the reported actual result.
+ * Values are reported exactly as the engine returned them: never reformatted, never
+ * reduced in precision. A DateTime at midnight with an offset, for example, keeps
+ * its offset rather than collapsing to Date precision.
  */
 export function formatActualValue(value: any): string {
 	if (Array.isArray(value)) {
@@ -244,8 +244,8 @@ export class CQLTestResults {
 				r.actual = String(act);
 			} else if (act !== undefined && act !== null && typeof act !== 'string') {
 				// Convert any non-string value to a schema-compliant string, preserving
-				// structure: lists, intervals and quantities are rendered in CQL syntax
-				// to mirror the expected value.
+				// structure: structured values are rendered in CQL syntax to mirror
+				// the expected value.
 				r.actual = formatActualValue(act);
 			}
 		}

--- a/src/test-results/cql-test-results.ts
+++ b/src/test-results/cql-test-results.ts
@@ -28,6 +28,94 @@ export class CQLTestResults {
 	public results: InternalTestResult[] = [];
 
 	/**
+	 * Returns true when a value is shaped like the runner's internal CQL Interval
+	 * representation.
+	 */
+	private static isIntervalValue(value: any): boolean {
+		return (
+			value !== null &&
+			typeof value === 'object' &&
+			('low' in value || 'high' in value) &&
+			('lowClosed' in value || 'highClosed' in value)
+		);
+	}
+
+	/**
+	 * Formats CQL date/time strings for report output.
+	 *
+	 * Preserve the value exactly as returned by the engine. Do not collapse
+	 * DateTime values at midnight with offsets (for example,
+	 * @2018-01-01T00:00:00-07:00) to Date precision, because doing so changes
+	 * the actual result reported by the server.
+	 */
+	private static formatCqlTemporalValue(value: string): string {
+		return value;
+	}
+
+	/**
+	 * Formats a primitive value for compact CQL-style report output.
+	 */
+	private static formatCqlValue(value: any): string {
+		if (value === null || value === undefined) {
+			return 'null';
+		}
+
+		if (typeof value === 'string') {
+			return CQLTestResults.formatCqlTemporalValue(value);
+		}
+
+		return String(value);
+	}
+
+	/**
+	 * Formats an internal interval object as CQL interval syntax.
+	 */
+	private static formatIntervalValue(interval: any): string {
+		const lowDelimiter = interval.lowClosed === false ? '(' : '[';
+		const highDelimiter = interval.highClosed === false ? ')' : ']';
+		return `Interval${lowDelimiter}${CQLTestResults.formatCqlValue(interval.low)}, ${CQLTestResults.formatCqlValue(interval.high)}${highDelimiter}`;
+	}
+
+	/**
+	 * Formats an actual result value for schema-compliant JSON output. Complex CQL
+	 * values are rendered in compact CQL syntax when possible; otherwise they are
+	 * JSON-serialized. String(object) produces "[object Object]" and loses
+	 * interval/list structure.
+	 */
+	public static formatActualValue(actual: any): string {
+		if (actual === null) {
+			return 'null';
+		}
+
+		if (typeof actual === 'string') {
+			return actual;
+		}
+
+		if (typeof actual === 'boolean' || typeof actual === 'number' || typeof actual === 'bigint') {
+			return String(actual);
+		}
+
+		if (CQLTestResults.isIntervalValue(actual)) {
+			return CQLTestResults.formatIntervalValue(actual);
+		}
+
+		if (Array.isArray(actual) && actual.every(CQLTestResults.isIntervalValue)) {
+			return `{ ${actual.map(interval => CQLTestResults.formatIntervalValue(interval)).join(', ')} }`;
+		}
+
+		if (Array.isArray(actual) && actual.every(value => typeof value === 'string')) {
+			return `{ ${actual.join(', ')} }`;
+		}
+
+		try {
+			const serialized = JSON.stringify(actual, null, 2);
+			return serialized === undefined ? String(actual) : serialized;
+		} catch {
+			return String(actual);
+		}
+	}
+
+	/**
 	 * Initializes CQLTestResults object with counts and results array.
 	 * @param cqlengine - The CQL engine instance used to run the tests.
 	 * @param testsRunDateTime - The date and time when the tests were run.
@@ -106,7 +194,9 @@ export class CQLTestResults {
 				...(result.responseStatus !== undefined && {
 					responseStatus: result.responseStatus,
 				}),
-				...(result.actual !== undefined && { actual: String(result.actual) }),
+				...(result.actual !== undefined && {
+					actual: CQLTestResults.formatActualValue(result.actual),
+				}),
 				...(result.expected && { expected: result.expected }),
 				...(result.error && {
 					error: {
@@ -188,8 +278,9 @@ export class CQLTestResults {
 			} else if (typeof act === 'number' && typeof exp === 'string') {
 				r.actual = String(act);
 			} else if (act !== undefined && act !== null && typeof act !== 'string') {
-				// Convert any non-string value to string for schema compliance
-				r.actual = String(act);
+				// Convert any non-string value to a schema-compliant string while
+				// preserving structure for arrays/objects.
+				r.actual = CQLTestResults.formatActualValue(act);
 			}
 		}
 	}


### PR DESCRIPTION
changes to fix display problems such as [object Object],[object Object]


---

Moved from #99, which was raised from a fork before I had committer access on this repository. Same work, same branch name, now hosted here so CI and reviews run against `cqframework` directly.
