### PR TITLE
Added invalid handling

### DIFF
--- a/src/services/test-runner.ts
+++ b/src/services/test-runner.ts
@@ -187,14 +187,19 @@ export class TestRunner {
 
 			result.responseStatus = response.status;
 			const responseBody = response.data;
-			const parsedExpected = cvl.parse(result.expected);
-			result.actual = resultExtractor.extract(responseBody, {
-				singletonListKeys: ValueMap.singletonListKeysFromExpected(parsedExpected),
-			});
 			const invalid = result.invalid;
+			const parsedExpected = result.expected !== undefined ? cvl.parse(result.expected) : undefined;
+			result.actual = resultExtractor.extract(responseBody, {
+				singletonListKeys:
+					parsedExpected !== undefined
+						? ValueMap.singletonListKeysFromExpected(parsedExpected)
+						: new Set<string>(),
+			});
 
 			if (invalid === 'true' || invalid === 'semantic') {
-				result.testStatus = response.status === 200 ? 'fail' : 'pass';
+				result.testStatus = this.isExpectedInvalidResult(response.status, result.actual)
+					? 'pass'
+					: 'fail';
 			} else {
 				if (response.status === 200) {
 					result.testStatus = resultsEqual(parsedExpected, result.actual)
@@ -224,6 +229,15 @@ export class TestRunner {
 		);
 
 		return result;
+	}
+
+	private isExpectedInvalidResult(responseStatus: number, actual: any): boolean {
+		if (responseStatus !== 200) {
+			return true;
+		}
+
+		const actualText = typeof actual === 'string' ? actual : JSON.stringify(actual);
+		return /EvaluationError:|OperationOutcome|Could not resolve call to operator/i.test(actualText);
 	}
 
 	private compareVersions(versionA: string | undefined, versionB: string | undefined): number {

--- a/src/shared/results-shared.ts
+++ b/src/shared/results-shared.ts
@@ -48,14 +48,23 @@ export class Result implements InternalTestResult {
 			} else {
 				this.expected = test.output as string;
 			}
+		} else if (this.invalid === 'true' || this.invalid === 'semantic') {
+			// Invalid tests are expected to fail during translation/evaluation.
+			// They do not need an <output>; allow the runner to execute them
+			// and mark them pass if the engine reports an error.
+			this.expected = undefined;
 		} else {
 			this.testStatus = 'skip';
 			this.skipMessage = 'No output specified';
 		}
 
-		this.capability = Array.isArray(test.capability)
-			? test.capability.map(({ code, value }) => ({ code, value }))
+		const testCapabilities = Array.isArray(test.capability)
+			? test.capability
+			: test.capability
+				? [test.capability]
 			: [];
+
+		this.capability = testCapabilities.map(({ code, value }) => ({ code, value }));
 	}
 }
 


### PR DESCRIPTION
Tests with "invalid": "semantic", handled as purposely failing as a valid test.


---

Moved from #98, which was raised from a fork before I had committer access on this repository. Same work, same branch name, now hosted here so CI and reviews run against `cqframework` directly.
