### PR TITLE
Concept codes comparison adjusted

### DIFF
--- a/src/shared/results-utils.ts
+++ b/src/shared/results-utils.ts
@@ -1,7 +1,51 @@
 /**
- * Compares two results for equality, handling nested objects and numbers
+ * Compares two results for equality, handling nested objects and numbers.
+ *
+ * Normalization handles representation differences that are not semantically
+ * meaningful for CQL comparison:
+ * - CVL can represent singleton Concept.codes as a single Code object while
+ *   the extractor can preserve codes as Code[].
+ * - Extracted runtime objects can include optional properties with undefined
+ *   values, such as system/version/display. Those should not make an object
+ *   unequal to the same object with those properties omitted.
  */
 export function resultsEqual(expected: any, actual: any): boolean {
+	return resultsEqualNormalized(
+		normalizeForComparison(expected),
+		normalizeForComparison(actual)
+	);
+}
+
+function normalizeForComparison(value: any): any {
+	if (Array.isArray(value)) {
+		return value.map(normalizeForComparison);
+	}
+
+	if (value && typeof value === 'object') {
+		const normalized: any = {};
+
+		for (const [key, child] of Object.entries(value)) {
+			// Ignore optional fields that are present only as undefined on runtime
+			// objects. Object.keys includes these fields, causing false mismatches
+			// against expected values where the fields are absent.
+			if (child === undefined) {
+				continue;
+			}
+
+			if (key === 'codes' && Array.isArray(child) && child.length === 1) {
+				normalized[key] = normalizeForComparison(child[0]);
+			} else {
+				normalized[key] = normalizeForComparison(child);
+			}
+		}
+
+		return normalized;
+	}
+
+	return value;
+}
+
+function resultsEqualNormalized(expected: any, actual: any): boolean {
 	if (expected === undefined && actual === undefined) {
 		return true;
 	}
@@ -33,7 +77,7 @@ export function resultsEqual(expected: any, actual: any): boolean {
 	if (expectedKeys.length !== actualKeys.length) return false;
 
 	for (const key of expectedKeys) {
-		if (!actualKeys.includes(key) || !resultsEqual(expected[key], actual[key])) {
+		if (!actualKeys.includes(key) || !resultsEqualNormalized(expected[key], actual[key])) {
 			return false;
 		}
 	}

--- a/src/shared/results-utils.ts
+++ b/src/shared/results-utils.ts
@@ -1,4 +1,9 @@
-import { getIntervalMeta, isIntervalShaped, type IntervalMeta } from './interval-utils.js';
+import {
+	getIntervalMeta,
+	setIntervalMeta,
+	isIntervalShaped,
+	type IntervalMeta,
+} from './interval-utils.js';
 
 /** Numeric tolerance for scalar comparison (interval boundaries use half their step). */
 const EPSILON = 0.00000001;
@@ -64,6 +69,17 @@ function normalizeForComparison(value: any): any {
 			} else {
 				normalized[key] = normalizeForComparison(child);
 			}
+		}
+
+		// The interval metadata the extractors record (FHIR-56226 point type and
+		// quantity-precision) lives under a non-enumerable Symbol key, so Object.entries
+		// above does not copy it onto the rebuilt object. Carry it across explicitly:
+		// intervalsEqual needs it to choose the boundary step, and without it every
+		// interval falls back to the decimal step. This only forwards what the wire
+		// already declared — nothing is inferred, so it cannot create a false match.
+		const meta = getIntervalMeta(value);
+		if (meta !== undefined) {
+			setIntervalMeta(normalized, meta);
 		}
 
 		return normalized;

--- a/src/test-results/cql-test-results.ts
+++ b/src/test-results/cql-test-results.ts
@@ -6,13 +6,14 @@ import { TestResultsSummary, CQLTestResultsData } from '../models/results-types.
 import { ResultsValidator } from '../conf/results-validator.js';
 
 /**
- * Formats an actual value for the results file. Lists (`{ a, b, c }`), intervals
- * (`Interval[low, high)`), quantities (`2.0 'cm2'`), Codes (`Code { code: 'x' }`)
- * and Concepts (`Concept { codes: { ... } }`) are rendered in CQL syntax so they
- * read like the expected value, which is kept in its original CQL/CVL notation.
+ * Formats an actual value for report output. Structured CQL values are rendered in
+ * CQL syntax so they read like the expected value, which is kept in its original
+ * CQL/CVL notation; anything else falls back to JSON, since String(object) yields
+ * "[object Object]" and loses the structure entirely.
  *
- * Values are reported exactly as the engine returned them; temporal values in
- * particular are never reformatted or reduced in precision.
+ * Values are reported exactly as the engine returned them: never reformatted, never
+ * reduced in precision. A DateTime at midnight with an offset, for example, keeps
+ * its offset rather than collapsing to Date precision.
  */
 export function formatActualValue(value: any): string {
 	if (Array.isArray(value)) {
@@ -287,8 +288,8 @@ export class CQLTestResults {
 				r.actual = String(act);
 			} else if (act !== undefined && act !== null && typeof act !== 'string') {
 				// Convert any non-string value to a schema-compliant string, preserving
-				// structure: lists, intervals, quantities, Codes and Concepts are
-				// rendered in CQL syntax to mirror the expected value.
+				// structure: structured values are rendered in CQL syntax to mirror
+				// the expected value.
 				r.actual = formatActualValue(act);
 			}
 		}

--- a/src/test-results/cql-test-results.ts
+++ b/src/test-results/cql-test-results.ts
@@ -27,6 +27,155 @@ export class CQLTestResults {
 	 */
 	public results: InternalTestResult[] = [];
 
+
+	/**
+	 * Returns true when a value is shaped like the runner's internal CQL Interval
+	 * representation.
+	 */
+	private static isIntervalValue(value: any): boolean {
+		return (
+			value !== null &&
+			typeof value === 'object' &&
+			('low' in value || 'high' in value) &&
+			('lowClosed' in value || 'highClosed' in value)
+		);
+	}
+
+	/**
+	 * Preserve temporal values exactly as returned by the engine.
+	 */
+	private static formatCqlTemporalValue(value: string): string {
+		return value;
+	}
+
+	/**
+	 * Formats a primitive value for compact CQL-style report output.
+	 */
+	private static formatCqlValue(value: any): string {
+		if (value === null || value === undefined) {
+			return 'null';
+		}
+
+		if (typeof value === 'string') {
+			return CQLTestResults.formatCqlTemporalValue(value);
+		}
+
+		return String(value);
+	}
+
+	/**
+	 * Formats an internal interval object as CQL interval syntax.
+	 */
+	private static formatIntervalValue(interval: any): string {
+		const lowDelimiter = interval.lowClosed === false ? '(' : '[';
+		const highDelimiter = interval.highClosed === false ? ')' : ']';
+		return `Interval${lowDelimiter}${CQLTestResults.formatCqlValue(interval.low)}, ${CQLTestResults.formatCqlValue(interval.high)}${highDelimiter}`;
+	}
+
+	/**
+	 * Returns true when a value is shaped like the CQL System.Code runtime representation.
+	 */
+	private static isCodeValue(value: any): boolean {
+		return value !== null && typeof value === 'object' && 'code' in value;
+	}
+
+	/**
+	 * Formats a CQL System.Code value as CQL constructor syntax.
+	 */
+	private static formatCodeValue(code: any): string {
+		const parts: string[] = [];
+
+		if (code.code !== undefined) {
+			parts.push(`code: '${code.code}'`);
+		}
+		if (code.system !== undefined) {
+			parts.push(`system: '${code.system}'`);
+		}
+		if (code.version !== undefined) {
+			parts.push(`version: '${code.version}'`);
+		}
+		if (code.display !== undefined) {
+			parts.push(`display: '${code.display}'`);
+		}
+
+		return `Code { ${parts.join(', ')} }`;
+	}
+
+	/**
+	 * Returns true when a value is shaped like the CQL System.Concept runtime representation.
+	 */
+	private static isConceptValue(value: any): boolean {
+		return (
+			value !== null &&
+			typeof value === 'object' &&
+			Array.isArray(value.codes) &&
+			value.codes.every((code: any) => CQLTestResults.isCodeValue(code))
+		);
+	}
+
+	/**
+	 * Formats a CQL System.Concept value as CQL constructor syntax.
+	 */
+	private static formatConceptValue(concept: any): string {
+		const codes = concept.codes
+			.map((code: any) => CQLTestResults.formatCodeValue(code))
+			.join(', ');
+		const parts = [`codes: { ${codes} }`];
+
+		if (concept.display !== undefined) {
+			parts.push(`display: '${concept.display}'`);
+		}
+
+		return `Concept { ${parts.join(', ')} }`;
+	}
+
+	/**
+	 * Formats an actual result value for schema-compliant JSON and console output.
+	 * Complex CQL values are rendered in compact CQL syntax when possible;
+	 * otherwise they are JSON-serialized. String(object) produces
+	 * "[object Object]" and loses structure.
+	 */
+	public static formatActualValue(actual: any): string {
+		if (actual === null) {
+			return 'null';
+		}
+
+		if (typeof actual === 'string') {
+			return actual;
+		}
+
+		if (typeof actual === 'boolean' || typeof actual === 'number' || typeof actual === 'bigint') {
+			return String(actual);
+		}
+
+		if (CQLTestResults.isConceptValue(actual)) {
+			return CQLTestResults.formatConceptValue(actual);
+		}
+
+		if (CQLTestResults.isCodeValue(actual)) {
+			return CQLTestResults.formatCodeValue(actual);
+		}
+
+		if (CQLTestResults.isIntervalValue(actual)) {
+			return CQLTestResults.formatIntervalValue(actual);
+		}
+
+		if (Array.isArray(actual) && actual.every(CQLTestResults.isIntervalValue)) {
+			return `{ ${actual.map(interval => CQLTestResults.formatIntervalValue(interval)).join(', ')} }`;
+		}
+
+		if (Array.isArray(actual) && actual.every(value => typeof value === 'string')) {
+			return `{ ${actual.join(', ')} }`;
+		}
+
+		try {
+			const serialized = JSON.stringify(actual, null, 2);
+			return serialized === undefined ? String(actual) : serialized;
+		} catch {
+			return String(actual);
+		}
+	}
+
 	/**
 	 * Initializes CQLTestResults object with counts and results array.
 	 * @param cqlengine - The CQL engine instance used to run the tests.
@@ -106,7 +255,7 @@ export class CQLTestResults {
 				...(result.responseStatus !== undefined && {
 					responseStatus: result.responseStatus,
 				}),
-				...(result.actual !== undefined && { actual: String(result.actual) }),
+				...(result.actual !== undefined && { actual: CQLTestResults.formatActualValue(result.actual) }),
 				...(result.expected && { expected: result.expected }),
 				...(result.error && {
 					error: {
@@ -188,8 +337,9 @@ export class CQLTestResults {
 			} else if (typeof act === 'number' && typeof exp === 'string') {
 				r.actual = String(act);
 			} else if (act !== undefined && act !== null && typeof act !== 'string') {
-				// Convert any non-string value to string for schema compliance
-				r.actual = String(act);
+				// Convert any non-string value to a schema-compliant string while
+				// preserving structure for arrays/objects.
+				r.actual = CQLTestResults.formatActualValue(act);
 			}
 		}
 	}

--- a/test/results-utils.test.ts
+++ b/test/results-utils.test.ts
@@ -520,3 +520,61 @@ test('open vs closed at the same value is unequal at every magnitude', () => {
 		)
 	).toBe(true);
 });
+
+// Comparison normalization rebuilds objects to collapse singleton Concept.codes and to
+// drop undefined-valued keys. Interval metadata is a non-enumerable Symbol property, so
+// a rebuild that only walks Object.entries silently loses it — and the failure is silent
+// in the worst way: every interval quietly falls back to the decimal step and nothing
+// reports an error. Guard the carry-forward.
+test('normalization preserves interval metadata through resultsEqual', () => {
+	const withMeta = (interval: any, meta: IntervalMeta) => {
+		setIntervalMeta(interval, meta);
+		return interval;
+	};
+
+	// Integer point type: the open expected high closes to 3 by stepping one, which only
+	// works if pointType survives normalization. With the decimal step this is false.
+	expect(
+		resultsEqual(
+			{ lowClosed: true, low: 1, highClosed: false, high: 4 },
+			withMeta({ lowClosed: true, low: 1, highClosed: true, high: 3 }, {
+				pointType: 'Integer',
+			})
+		)
+	).toBe(true);
+
+	// Declared quantity-precision: [1.0, 1.4) closes to 1.3 at precision 1.
+	expect(
+		resultsEqual(
+			{ lowClosed: true, low: 1.0, highClosed: false, high: 1.4 },
+			withMeta({ lowClosed: true, low: 1.0, highClosed: true, high: 1.3 }, {
+				pointType: 'Decimal',
+				lowPrecision: 1,
+				highPrecision: 1,
+			})
+		)
+	).toBe(true);
+
+	// Metadata must survive for intervals nested inside a list, since normalization
+	// recurses through arrays.
+	expect(
+		resultsEqual(
+			[{ lowClosed: true, low: 1, highClosed: false, high: 4 }],
+			[
+				withMeta({ lowClosed: true, low: 1, highClosed: true, high: 3 }, {
+					pointType: 'Integer',
+				}),
+			]
+		)
+	).toBe(true);
+
+	// Carrying metadata forward must not make genuinely different intervals equal.
+	expect(
+		resultsEqual(
+			{ lowClosed: true, low: 1, highClosed: false, high: 4 },
+			withMeta({ lowClosed: true, low: 1, highClosed: true, high: 5 }, {
+				pointType: 'Integer',
+			})
+		)
+	).toBe(false);
+});


### PR DESCRIPTION
Server returning correct code, but test is failing due to format and test evaluation.

To duplicate the test that fails, run the following
```
<?xml version="1.0" encoding="utf-8"?>
<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhirpath/tests" xsi:schemaLocation="http://hl7.org/fhirpath/tests ../../testSchema/testSchema.xsd"
       name="CqlTypeOperatorsTest">
	<group name="SingleTest" version="1.0">
		<test name="CodeToConcept1" version="1.0">
			<capability code="type-operators" />
			<expression>ToConcept(Code { code: '8480-6' })</expression>
			<output>Concept { codes: { Code { code: '8480-6' } } }</output>
		</test>
	</group>
</tests>
```


---

Moved from #100, which was raised from a fork before I had committer access on this repository. Same work, same branch name, now hosted here so CI and reviews run against `cqframework` directly.

This branch has moved on since #100: `main` is merged in, and it carries an additional fix. `normalizeForComparison` rebuilds objects via `Object.entries`, which does not see the non-enumerable Symbol property #110 uses to record a numeric interval's point type and `quantity-precision`. Rebuilding stripped that metadata, so `intervalsEqual` fell back to the decimal step and 11 comparison tests failed once #110 landed. The metadata is now carried across, with a regression test that fails without it. 185 passing, `tsc --noEmit` clean.
