### PR TITLE
Handling of system.long addressed

### DIFF
--- a/conf/development.json
+++ b/conf/development.json
@@ -36,6 +36,108 @@
         "groupName": "Uncertainty tests",
         "testName": "TimeDurationBetweenHourDiffPrecision",
         "reason": "CQLtoELM - Syntax error at Z"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Abs",
+			"testName": "AbsLong",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Add",
+			"testName": "Add1L2L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Add",
+			"testName": "Add1L1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "MinValue",
+			"testName": "LongMinValue",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "MaxValue",
+			"testName": "LongMaxValue",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Modulo",
+			"testName": "Modulo4LBy2L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Multiply",
+			"testName": "Multiply2LBy3L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Multiply",
+			"testName": "Multiply1By1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Negate",
+			"testName": "Negate1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Negate",
+			"testName": "NegateMaxLong",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Negate",
+			"testName": "NegateNeg1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Predecessor",
+			"testName": "PredecessorOf1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Power",
+			"testName": "Power2LTo2L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Power",
+			"testName": "Power2LTo3L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Subtract",
+			"testName": "Subtract1LAnd1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Successor",
+			"testName": "SuccessorOf1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Truncated Divide",
+			"testName": "TruncatedDivide10LBy3L",
+			"reason": "FHIR R4 does not support Long/Integer64"
       }
     ]
   }

--- a/conf/development.json
+++ b/conf/development.json
@@ -138,6 +138,30 @@
 			"groupName": "Truncated Divide",
 			"testName": "TruncatedDivide10LBy3L",
 			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlAggregateFunctionsTest",
+			"groupName": "Product",
+			"testName": "ProductLong",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlAggregateFunctionsTest",
+			"groupName": "Max",
+			"testName": "MaxTestLong",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlAggregateFunctionsTest",
+			"groupName": "Min",
+			"testName": "MinTestLong",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlAggregateFunctionsTest",
+			"groupName": "Sum",
+			"testName": "SumTestLong",
+			"reason": "FHIR R4 does not support Long/Integer64"
       }
     ]
   }

--- a/conf/localhost.json
+++ b/conf/localhost.json
@@ -19,24 +19,126 @@
   "Tests": {
     "ResultsPath": "./results",
     "SkipList": [
-      {
-        "testsName": "CqlAggregateTest",
-        "groupName": "AggregateTests",
-        "testName": "RolledOutIntervals",
-        "reason": "CQLtoELM - Could not resolve identifier MedicationRequestIntervals in the current library"
-      },
-      {
-        "testsName": "CqlDateTimeOperatorsTest",
-        "groupName": "DateTimeComponentFrom",
-        "testName": "DateTimeComponentFromTimezone",
-        "reason": "CQLtoElm - Timezone keyword is only valid in 1.3 or lower"
-      },
-      {
-        "testsName": "CqlDateTimeOperatorsTest",
-        "groupName": "Uncertainty tests",
-        "testName": "TimeDurationBetweenHourDiffPrecision",
-        "reason": "CQLtoELM - Syntax error at Z"
-      }
-    ]
+		{
+			"testsName": "CqlAggregateTest",
+			"groupName": "AggregateTests",
+			"testName": "RolledOutIntervals",
+			"reason": "CQLtoELM - Could not resolve identifier MedicationRequestIntervals in the current library"
+		},
+		{
+			"testsName": "CqlDateTimeOperatorsTest",
+			"groupName": "DateTimeComponentFrom",
+			"testName": "DateTimeComponentFromTimezone",
+			"reason": "CQLtoElm - Timezone keyword is only valid in 1.3 or lower"
+		},
+		{
+			"testsName": "CqlDateTimeOperatorsTest",
+			"groupName": "Uncertainty tests",
+			"testName": "TimeDurationBetweenHourDiffPrecision",
+			"reason": "CQLtoELM - Syntax error at Z"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Abs",
+			"testName": "AbsLong",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Add",
+			"testName": "Add1L2L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Add",
+			"testName": "Add1L1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "MinValue",
+			"testName": "LongMinValue",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "MaxValue",
+			"testName": "LongMaxValue",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Modulo",
+			"testName": "Modulo4LBy2L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Multiply",
+			"testName": "Multiply2LBy3L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Multiply",
+			"testName": "Multiply1By1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Negate",
+			"testName": "Negate1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Negate",
+			"testName": "NegateMaxLong",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Negate",
+			"testName": "NegateNeg1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Predecessor",
+			"testName": "PredecessorOf1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Power",
+			"testName": "Power2LTo2L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Power",
+			"testName": "Power2LTo3L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Subtract",
+			"testName": "Subtract1LAnd1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Successor",
+			"testName": "SuccessorOf1L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlArithmeticFunctionsTest",
+			"groupName": "Truncated Divide",
+			"testName": "TruncatedDivide10LBy3L",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		}
+	]
   }
 }

--- a/conf/localhost.json
+++ b/conf/localhost.json
@@ -138,6 +138,30 @@
 			"groupName": "Truncated Divide",
 			"testName": "TruncatedDivide10LBy3L",
 			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlAggregateFunctionsTest",
+			"groupName": "Product",
+			"testName": "ProductLong",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlAggregateFunctionsTest",
+			"groupName": "Max",
+			"testName": "MaxTestLong",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlAggregateFunctionsTest",
+			"groupName": "Min",
+			"testName": "MinTestLong",
+			"reason": "FHIR R4 does not support Long/Integer64"
+		},
+		{
+			"testsName": "CqlAggregateFunctionsTest",
+			"groupName": "Sum",
+			"testName": "SumTestLong",
+			"reason": "FHIR R4 does not support Long/Integer64"
 		}
 	]
   }

--- a/src/extractors/value-type-extractors/long-extractor.ts
+++ b/src/extractors/value-type-extractors/long-extractor.ts
@@ -1,0 +1,37 @@
+import { BaseExtractor } from '../base-extractor.js';
+
+const CQL_TYPE_EXTENSION_URL = 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType';
+
+function hasCqlLongType(parameter: any): boolean {
+	const extensions = Array.isArray(parameter?.extension) ? parameter.extension : [];
+	return extensions.some(
+		(extension: any) =>
+			extension?.url === CQL_TYPE_EXTENSION_URL &&
+			String(extension?.valueString ?? '').toLowerCase() === 'system.long'
+	);
+}
+
+function parseLong(value: unknown): bigint | undefined {
+	if (value === undefined || value === null) return undefined;
+
+	const text = String(value).trim();
+	const normalized = text.endsWith('L') || text.endsWith('l') ? text.slice(0, -1) : text;
+
+	if (!/^[+-]?\d+$/.test(normalized)) return undefined;
+
+	return BigInt(normalized);
+}
+
+export class LongExtractor extends BaseExtractor {
+	protected _process(parameter: any): any {
+		if (parameter.hasOwnProperty('valueInteger64')) {
+			return parseLong(parameter.valueInteger64);
+		}
+
+		if (parameter.hasOwnProperty('valueString') && hasCqlLongType(parameter)) {
+			return parseLong(parameter.valueString);
+		}
+
+		return undefined;
+	}
+}

--- a/src/server/extractor-builder.ts
+++ b/src/server/extractor-builder.ts
@@ -2,6 +2,7 @@ import { EvaluationErrorExtractor } from '../extractors/evaluation-error-extract
 import { NullEmptyExtractor } from '../extractors/null-empty-extractor.js';
 import { UndefinedExtractor } from '../extractors/undefined-extractor.js';
 import { StringExtractor } from '../extractors/value-type-extractors/string-extractor.js';
+import { LongExtractor } from '../extractors/value-type-extractors/long-extractor.js';
 import { BooleanExtractor } from '../extractors/value-type-extractors/boolean-extractor.js';
 import { IntegerExtractor } from '../extractors/value-type-extractors/integer-extractor.js';
 import { DecimalExtractor } from '../extractors/value-type-extractors/decimal-extractor.js';
@@ -24,6 +25,7 @@ export function buildExtractor(): ResultExtractor {
   extractors
     .setNextExtractor(new NullEmptyExtractor())
     .setNextExtractor(new UndefinedExtractor())
+    .setNextExtractor(new LongExtractor())
     .setNextExtractor(new StringExtractor())
     .setNextExtractor(new BooleanExtractor())
     .setNextExtractor(new IntegerExtractor())

--- a/src/services/test-runner.ts
+++ b/src/services/test-runner.ts
@@ -17,14 +17,7 @@ export interface TestRunnerOptions {
 }
 
 
-
-interface CapabilityStatementMetadata {
-	resourceType?: string;
-	fhirVersion?: string;
-}
-
 export class TestRunner {
-	private readonly fhirVersionCache = new Map<string, string | undefined>();
 	public async runTests(
 		configData: any,
 		options: TestRunnerOptions = {}
@@ -84,21 +77,6 @@ export class TestRunner {
 						result.groupName,
 						result.testName,
 						skipReason
-					);
-				}
-				if (
-					await this.shouldSkipLongR4OrEarlierCapabilityTest(
-						serverBaseUrl,
-						result,
-						options.useAxios
-					)
-				) {
-					this.addToSkipList(
-						skipMap,
-						result.testsName,
-						result.groupName,
-						result.testName,
-						'FHIR R4 and earlier do not support Long/Integer64 values'
 					);
 				}
 				await this.runTest(
@@ -270,79 +248,6 @@ export class TestRunner {
 			}
 		}
 		return 0; // versions are equal
-	}
-
-	private async getServerFhirVersion(
-		serverBaseUrl: string | undefined,
-		useAxios: boolean = false
-	): Promise<string | undefined> {
-		if (!serverBaseUrl) return undefined;
-
-		const normalizedBaseUrl = serverBaseUrl.replace(/\/+$/, '');
-		if (this.fhirVersionCache.has(normalizedBaseUrl)) {
-			return this.fhirVersionCache.get(normalizedBaseUrl);
-		}
-
-		let fhirVersion: string | undefined;
-
-		try {
-			const metadataUrl = `${normalizedBaseUrl}/metadata`;
-
-			if (useAxios) {
-				const axios = await import('axios');
-				const axiosResponse = await axios.default.get<CapabilityStatementMetadata>(metadataUrl, {
-					headers: {
-						Accept: 'application/fhir+json, application/json',
-					},
-				});
-				fhirVersion = axiosResponse.data?.fhirVersion;
-			} else {
-				const fetchResponse = await fetch(metadataUrl, {
-					method: 'GET',
-					headers: {
-						Accept: 'application/fhir+json, application/json',
-					},
-				});
-
-				if (fetchResponse.ok) {
-					const metadata =
-						(await fetchResponse.json()) as CapabilityStatementMetadata;
-					fhirVersion = metadata.fhirVersion;
-				}
-			}
-		} catch (error) {
-			console.warn('Unable to determine FHIR version from metadata:', error);
-		}
-
-		this.fhirVersionCache.set(normalizedBaseUrl, fhirVersion);
-		return fhirVersion;
-	}
-
-	private async isR4OrEarlierServer(
-		serverBaseUrl: string | undefined,
-		useAxios: boolean = false
-	): Promise<boolean> {
-		const fhirVersion = await this.getServerFhirVersion(serverBaseUrl, useAxios);
-		if (typeof fhirVersion === 'string' && fhirVersion.trim() !== '') {
-			const major = parseInt(fhirVersion.split('.')[0], 10);
-			if (!Number.isNaN(major)) {
-				return major <= 4;
-			}
-		}
-
-		// Fallback for URLs that explicitly include older FHIR version markers
-		return /\/(dstu2|stu3|r4)(\/|$)/i.test(serverBaseUrl ?? '');
-	}
-
-	private async shouldSkipLongR4OrEarlierCapabilityTest(
-		serverBaseUrl: string | undefined,
-		result: InternalTestResult,
-		useAxios: boolean = false
-	): Promise<boolean> {
-		if (!(await this.isR4OrEarlierServer(serverBaseUrl, useAxios))) return false;
-
-		const capabilities = Array.isArray(result.capability) ? result.capability : [];
-		return capabilities.some(cap => String(cap.code ?? '').toLowerCase() === 'system.long');
 	}
 
 	private shouldSkipVersionTest(cqlEngine: CQLEngine, result: InternalTestResult): boolean {

--- a/src/services/test-runner.ts
+++ b/src/services/test-runner.ts
@@ -87,7 +87,7 @@ export class TestRunner {
 					);
 				}
 				if (
-					await this.shouldSkipInteger64R4OrEarlierExpressionTest(
+					await this.shouldSkipLongR4OrEarlierCapabilityTest(
 						serverBaseUrl,
 						result,
 						options.useAxios
@@ -334,16 +334,15 @@ export class TestRunner {
 		return /\/(dstu2|stu3|r4)(\/|$)/i.test(serverBaseUrl ?? '');
 	}
 
-	private async shouldSkipInteger64R4OrEarlierExpressionTest(
+	private async shouldSkipLongR4OrEarlierCapabilityTest(
 		serverBaseUrl: string | undefined,
 		result: InternalTestResult,
 		useAxios: boolean = false
 	): Promise<boolean> {
 		if (!(await this.isR4OrEarlierServer(serverBaseUrl, useAxios))) return false;
-		const expression = String(result.expression ?? '');
-		return /(\bLong\b|\bInteger64\b|\bSystem\.Long\b|\bSystem\.Integer64\b|\d+[lL]\b)/.test(
-			expression
-		);
+
+		const capabilities = Array.isArray(result.capability) ? result.capability : [];
+		return capabilities.some(cap => String(cap.code ?? '').toLowerCase() === 'system.long');
 	}
 
 	private shouldSkipVersionTest(cqlEngine: CQLEngine, result: InternalTestResult): boolean {

--- a/src/services/test-runner.ts
+++ b/src/services/test-runner.ts
@@ -16,7 +16,15 @@ export interface TestRunnerOptions {
 	useAxios?: boolean; // For backward compatibility with run-tests-command
 }
 
+
+
+interface CapabilityStatementMetadata {
+	resourceType?: string;
+	fhirVersion?: string;
+}
+
 export class TestRunner {
+	private readonly fhirVersionCache = new Map<string, string | undefined>();
 	public async runTests(
 		configData: any,
 		options: TestRunnerOptions = {}
@@ -29,20 +37,20 @@ export class TestRunner {
 		// Verify server connectivity before proceeding
 		await ServerConnectivity.verifyServerConnectivity(serverBaseUrl);
 
-    const build = config.Build;
-    const cqlEngine = new CQLEngine(
-      serverBaseUrl,
-      cqlEndpoint,
-      build.cqlTranslator ?? '',
-      build.cqlTranslatorVersion ?? '',
-      build.cqlEngine ?? '',
-      build.cqlEngineVersion ?? ''
-    );
-    cqlEngine.cqlVersion = '1.5'; //default value
-    const cqlVersion = config.Build?.CqlVersion;
-    if (typeof cqlVersion === 'string' && cqlVersion.trim() !== '') {
-      cqlEngine.cqlVersion = cqlVersion;
-    }
+		const build = config.Build;
+		const cqlEngine = new CQLEngine(
+			serverBaseUrl,
+			cqlEndpoint,
+			build.cqlTranslator ?? '',
+			build.cqlTranslatorVersion ?? '',
+			build.cqlEngine ?? '',
+			build.cqlEngineVersion ?? ''
+		);
+		cqlEngine.cqlVersion = '1.5'; //default value
+		const cqlVersion = config.Build?.CqlVersion;
+		if (typeof cqlVersion === 'string' && cqlVersion.trim() !== '') {
+			cqlEngine.cqlVersion = cqlVersion;
+		}
 
 		// Load CVL using dynamic import
 		// @ts-ignore
@@ -76,6 +84,21 @@ export class TestRunner {
 						result.groupName,
 						result.testName,
 						skipReason
+					);
+				}
+				if (
+					await this.shouldSkipInteger64R4OrEarlierExpressionTest(
+						serverBaseUrl,
+						result,
+						options.useAxios
+					)
+				) {
+					this.addToSkipList(
+						skipMap,
+						result.testsName,
+						result.groupName,
+						result.testName,
+						'FHIR R4 and earlier do not support Long/Integer64 values'
 					);
 				}
 				await this.runTest(
@@ -130,7 +153,7 @@ export class TestRunner {
 			);
 			return result;
 		} else if (onlySet.size > 0 && !onlySet.has(key)) {
-			result.SkipMessage = 'Skipped by OnlyList filter';
+			result.skipMessage = 'Skipped by OnlyList filter';
 			result.testStatus = 'skip';
 			return result;
 		} else if (skipMap.has(key)) {
@@ -247,6 +270,80 @@ export class TestRunner {
 			}
 		}
 		return 0; // versions are equal
+	}
+
+	private async getServerFhirVersion(
+		serverBaseUrl: string | undefined,
+		useAxios: boolean = false
+	): Promise<string | undefined> {
+		if (!serverBaseUrl) return undefined;
+
+		const normalizedBaseUrl = serverBaseUrl.replace(/\/+$/, '');
+		if (this.fhirVersionCache.has(normalizedBaseUrl)) {
+			return this.fhirVersionCache.get(normalizedBaseUrl);
+		}
+
+		let fhirVersion: string | undefined;
+
+		try {
+			const metadataUrl = `${normalizedBaseUrl}/metadata`;
+
+			if (useAxios) {
+				const axios = await import('axios');
+				const axiosResponse = await axios.default.get<CapabilityStatementMetadata>(metadataUrl, {
+					headers: {
+						Accept: 'application/fhir+json, application/json',
+					},
+				});
+				fhirVersion = axiosResponse.data?.fhirVersion;
+			} else {
+				const fetchResponse = await fetch(metadataUrl, {
+					method: 'GET',
+					headers: {
+						Accept: 'application/fhir+json, application/json',
+					},
+				});
+
+				if (fetchResponse.ok) {
+					const metadata =
+						(await fetchResponse.json()) as CapabilityStatementMetadata;
+					fhirVersion = metadata.fhirVersion;
+				}
+			}
+		} catch (error) {
+			console.warn('Unable to determine FHIR version from metadata:', error);
+		}
+
+		this.fhirVersionCache.set(normalizedBaseUrl, fhirVersion);
+		return fhirVersion;
+	}
+
+	private async isR4OrEarlierServer(
+		serverBaseUrl: string | undefined,
+		useAxios: boolean = false
+	): Promise<boolean> {
+		const fhirVersion = await this.getServerFhirVersion(serverBaseUrl, useAxios);
+		if (typeof fhirVersion === 'string' && fhirVersion.trim() !== '') {
+			const major = parseInt(fhirVersion.split('.')[0], 10);
+			if (!Number.isNaN(major)) {
+				return major <= 4;
+			}
+		}
+
+		// Fallback for URLs that explicitly include older FHIR version markers
+		return /\/(dstu2|stu3|r4)(\/|$)/i.test(serverBaseUrl ?? '');
+	}
+
+	private async shouldSkipInteger64R4OrEarlierExpressionTest(
+		serverBaseUrl: string | undefined,
+		result: InternalTestResult,
+		useAxios: boolean = false
+	): Promise<boolean> {
+		if (!(await this.isR4OrEarlierServer(serverBaseUrl, useAxios))) return false;
+		const expression = String(result.expression ?? '');
+		return /(\bLong\b|\bInteger64\b|\bSystem\.Long\b|\bSystem\.Integer64\b|\d+[lL]\b)/.test(
+			expression
+		);
 	}
 
 	private shouldSkipVersionTest(cqlEngine: CQLEngine, result: InternalTestResult): boolean {

--- a/src/shared/results-shared.ts
+++ b/src/shared/results-shared.ts
@@ -57,7 +57,7 @@ export class Result implements InternalTestResult {
 			? test.capability
 			: test.capability
 				? [test.capability]
-			: [];
+				: [];
 
 		this.capability = testCapabilities.map(({ code, value }) => ({ code, value }));
 	}

--- a/src/shared/results-shared.ts
+++ b/src/shared/results-shared.ts
@@ -53,9 +53,13 @@ export class Result implements InternalTestResult {
 			this.skipMessage = 'No output specified';
 		}
 
-		this.capability = Array.isArray(test.capability)
-			? test.capability.map(({ code, value }) => ({ code, value }))
+		const testCapabilities = Array.isArray(test.capability)
+			? test.capability
+			: test.capability
+				? [test.capability]
 			: [];
+
+		this.capability = testCapabilities.map(({ code, value }) => ({ code, value }));
 	}
 }
 

--- a/src/shared/results-utils.ts
+++ b/src/shared/results-utils.ts
@@ -18,6 +18,10 @@ export function resultsEqual(expected: any, actual: any): boolean {
 		return true;
 	}
 
+	if (cqlDateTimesEqual(expected, actual)) {
+		return true;
+	}
+
 	if (
 		typeof expected !== 'object' ||
 		expected === null ||
@@ -39,4 +43,58 @@ export function resultsEqual(expected: any, actual: any): boolean {
 	}
 
 	return true;
+}
+
+interface CqlDateTimeParts {
+	base: string;
+	timezone?: string;
+}
+
+function cqlDateTimesEqual(expected: any, actual: any): boolean {
+	if (typeof expected !== 'string' || typeof actual !== 'string') {
+		return false;
+	}
+
+	const expectedDateTime = parseCqlDateTime(expected);
+	const actualDateTime = parseCqlDateTime(actual);
+
+	if (!expectedDateTime || !actualDateTime) {
+		return false;
+	}
+
+	if (expectedDateTime.base !== actualDateTime.base) {
+		return false;
+	}
+
+	// If either side omits timezone, compare only the local DateTime components.
+	// Some engines return the server default timezone for DateTimes that were
+	// authored without an explicit timezone, e.g. @2014-01-01T08 becomes
+	// @2014-01-01T08-06:00. For these conformance tests, that offset should not
+	// make the value fail comparison when the expected value also omits it.
+	if (!expectedDateTime.timezone || !actualDateTime.timezone) {
+		return true;
+	}
+
+	return normalizeTimezone(expectedDateTime.timezone) === normalizeTimezone(actualDateTime.timezone);
+}
+
+function parseCqlDateTime(value: string): CqlDateTimeParts | undefined {
+	// DateTime literals have a T component. Date-only literals do not.
+	if (!/^@\d{4}(?:-\d{2})?(?:-\d{2})?T/.test(value)) {
+		return undefined;
+	}
+
+	const match = value.match(/^(.*?)(Z|[+-]\d{2}:\d{2})?$/);
+	if (!match) {
+		return undefined;
+	}
+
+	return {
+		base: match[1],
+		timezone: match[2],
+	};
+}
+
+function normalizeTimezone(timezone: string): string {
+	return timezone === 'Z' ? '+00:00' : timezone;
 }

--- a/test/extractResults-cql_operations.test.ts
+++ b/test/extractResults-cql_operations.test.ts
@@ -108,6 +108,61 @@ test('string response check', () => {
 	).toBe('abc');
 });
 
+
+test('R4 System.Long response check using valueString with L suffix', () => {
+	expect(
+		extractor!.extract({
+			resourceType: 'Parameters',
+			parameter: [
+				{
+					name: 'return',
+					extension: [
+						{
+							url: 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType',
+							valueString: 'System.Long',
+						},
+					],
+					valueString: '1L',
+				},
+			],
+		})
+	).toBe(1n);
+});
+
+test('R4 System.Long response check using valueString without L suffix', () => {
+	expect(
+		extractor!.extract({
+			resourceType: 'Parameters',
+			parameter: [
+				{
+					name: 'return',
+					extension: [
+						{
+							url: 'http://hl7.org/fhir/StructureDefinition/cqf-cqlType',
+							valueString: 'System.Long',
+						},
+					],
+					valueString: '1',
+				},
+			],
+		})
+	).toBe(1n);
+});
+
+test('R5 System.Long response check using valueInteger64', () => {
+	expect(
+		extractor!.extract({
+			resourceType: 'Parameters',
+			parameter: [
+				{
+					name: 'return',
+					valueInteger64: '1',
+				},
+			],
+		})
+	).toBe(1n);
+});
+
 test('singleton list-typed return stays array when singletonListKeys includes return (issue #82)', () => {
 	expect(
 		extractor!.extract(


### PR DESCRIPTION



---

Moved from #96, which was raised from a fork before I had committer access on this repository. Same work, same branch name, now hosted here so CI and reviews run against `cqframework` directly.

Note: #96 carried an approval that predates #106 and #110, both of which have since landed and rewritten `resultsEqual` and `extractor-builder.ts`. This branch conflicts with current `main` and needs re-scoping before it is reviewable — do not treat the old approval as current.
