### PR TITLE
Normalize a single <capability> element so it is not dropped

### DIFF
--- a/src/models/test-types.ts
+++ b/src/models/test-types.ts
@@ -30,7 +30,8 @@ export interface Test {
 	ordered?: boolean;
 	checkOrderedFunctions?: boolean;
 	expression: string | TestExpression;
-	capability: CapabilityKV[];
+	/** One <capability> element parses to a bare object; two or more to an array. */
+	capability?: CapabilityKV | CapabilityKV[];
 	output?: string | TestOutput | string[] | TestOutput[];
 }
 

--- a/src/shared/results-shared.ts
+++ b/src/shared/results-shared.ts
@@ -56,9 +56,18 @@ export class Result implements InternalTestResult {
 			this.skipMessage = 'No output specified';
 		}
 
-		this.capability = Array.isArray(test.capability)
-			? test.capability.map(({ code, value }) => ({ code, value }))
-			: [];
+		// The XML parser yields a bare object when a test declares exactly one
+		// <capability> element, and an array only for two or more. Matching on
+		// Array.isArray alone therefore dropped the capability for every
+		// single-capability test — the large majority of the suite. Normalize to an
+		// array first.
+		const testCapabilities = Array.isArray(test.capability)
+			? test.capability
+			: test.capability !== undefined && test.capability !== null
+				? [test.capability]
+				: [];
+
+		this.capability = testCapabilities.map(({ code, value }) => ({ code, value }));
 	}
 }
 

--- a/test/results-shared.test.ts
+++ b/test/results-shared.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest';
+
+import { Result } from '../src/shared/results-shared.js';
+import { Test } from '../src/models/test-types.js';
+
+const asTest = (test: any): Test => test as Test;
+
+describe('Result capability normalization', () => {
+	// The XML parser gives a bare object for a single <capability> element and an array
+	// only for two or more. Matching on Array.isArray alone silently dropped the
+	// capability for every single-capability test, which is most of the suite.
+	test('keeps the capability when a test declares exactly one', () => {
+		const result = new Result(
+			'CqlIntervalOperatorsTest',
+			'Interval',
+			asTest({
+				name: 'TimeIntervalTest',
+				expression: 'Interval[@T00:00:00.000, @T23:59:59.599]',
+				output: 'Interval[@T00:00:00.000, @T23:59:59.599]',
+				capability: { code: 'interval-operators', value: 'true' },
+			})
+		);
+
+		expect(result.capability).toStrictEqual([{ code: 'interval-operators', value: 'true' }]);
+	});
+
+	test('keeps every capability when a test declares several', () => {
+		const result = new Result(
+			'CqlListOperatorsTest',
+			'List',
+			asTest({
+				name: 'ListTest',
+				expression: '{ 1, 2 }',
+				output: '{ 1, 2 }',
+				capability: [
+					{ code: 'list-operators', value: 'true' },
+					{ code: 'interval-operators', value: 'false' },
+				],
+			})
+		);
+
+		expect(result.capability).toStrictEqual([
+			{ code: 'list-operators', value: 'true' },
+			{ code: 'interval-operators', value: 'false' },
+		]);
+	});
+
+	test('yields an empty list when a test declares none', () => {
+		const result = new Result(
+			'CqlTest',
+			'Group',
+			asTest({ name: 'NoCapability', expression: '1', output: '1' })
+		);
+
+		expect(result.capability).toStrictEqual([]);
+	});
+
+	test('normalization does not disturb the rest of the Result', () => {
+		const result = new Result(
+			'CqlTest',
+			'Group',
+			asTest({
+				name: 'Simple',
+				expression: '1 + 1',
+				output: '2',
+				capability: { code: 'arithmetic', value: 'true' },
+			})
+		);
+
+		expect(result.testsName).toBe('CqlTest');
+		expect(result.groupName).toBe('Group');
+		expect(result.testName).toBe('Simple');
+		expect(result.expression).toBe('1 + 1');
+		expect(result.expected).toBe('2');
+		expect(result.invalid).toBe('false');
+	});
+});


### PR DESCRIPTION
`Result` matched `test.capability` on `Array.isArray` alone and fell through to `[]`. The XML parser yields a bare object when a test declares exactly one `<capability>` element and an array only for two or more, so every single-capability test reported no capabilities at all — **7,390 tests in the suite, against 513 with two or more**. Worst affected are `CqlIntervalOperatorsTest` (2,091), `CqlListOperatorsTest` (1,020) and `CqlDateTimeOperatorsTest` (1,006).

## Changes

- `results-shared.ts` — normalize `test.capability` to an array before mapping.
- `test-types.ts` — widen `Test.capability` to `CapabilityKV | CapabilityKV[]`, so the declared type matches what the parser actually produces instead of hiding the case that was being missed. Verified this does not cascade to other call sites.
- `test/results-shared.test.ts` — new; four tests covering one capability, several, none, and that normalization leaves the rest of the `Result` untouched. Each fails without the fix.

Impact is confined to reporting: `capability` feeds the `capabilities` field in the results file and the MCP server payload, and does not gate execution, so no pass/fail verdict changes.

`tsc --noEmit` clean, 188 tests passing. Merges cleanly against `main`, and independently of #113 and #115 — it touches only `results-shared.ts` and `test-types.ts`, which neither of those PRs modifies.

## Replaces #114

#114 also carried invalid-test handling, all of which #116 has since delivered in a better form — `responseIndicatesError` checks the response status and looks structurally for an `evaluation error` parameter, where #114 regex-matched the stringified actual value. The `parsedExpected` guard and the "invalid tests need no `<output>`" rule are also already on `main`, and the `singletonListKeys` guard is unnecessary because `singletonListKeysFromExpected` already returns an empty set for a non-array input.

Only the capability fix remained, so this PR is that alone. #114 was raised from a branch name that no longer describes the change, and a PR's head branch cannot be repointed, hence the new PR.
