### PR TITLE
Carry group-level <capability> onto each test result

### DIFF
--- a/src/models/test-types.ts
+++ b/src/models/test-types.ts
@@ -41,6 +41,8 @@ export interface TestGroup {
 	description?: string;
 	reference?: string;
 	notes?: string;
+	/** One <capability> element parses to a bare object; two or more to an array. */
+	capability?: CapabilityKV | CapabilityKV[];
 	test: Test[];
 }
 

--- a/src/server/test-execution-service.ts
+++ b/src/server/test-execution-service.ts
@@ -47,7 +47,7 @@ export class TestExecutionService {
 				for (const test of group.test) {
 					if (test.name !== testName) continue;
 
-					const result = new Result(testsName, groupName, test);
+					const result = new Result(testsName, groupName, test, group.capability);
 					await runTest(result, ctx);
 
 					const testResults = new CQLTestResults(ctx.cqlEngine);
@@ -72,7 +72,7 @@ export class TestExecutionService {
 			for (const group of testSuite.group) {
 				if (group.name !== groupName || !group.test) continue;
 				for (const test of group.test) {
-					const result = new Result(testsName, groupName, test);
+					const result = new Result(testsName, groupName, test, group.capability);
 					await runTest(result, ctx);
 					results.add(result);
 				}

--- a/src/shared/results-shared.ts
+++ b/src/shared/results-shared.ts
@@ -1,6 +1,20 @@
 import { Tests, Test, InternalTestResult, CapabilityKV } from '../models/test-types.js';
 import { Parameters } from 'fhir/r4';
 
+/**
+ * The XML parser yields a bare object when an element declares exactly one <capability>
+ * and an array only for two or more, so both shapes have to be tolerated.
+ */
+function normalizeCapabilities(capability: CapabilityKV | CapabilityKV[] | undefined): CapabilityKV[] {
+	const declared = Array.isArray(capability)
+		? capability
+		: capability !== undefined && capability !== null
+			? [capability]
+			: [];
+
+	return declared.map(({ code, value }) => ({ code, value }));
+}
+
 export class Result implements InternalTestResult {
 	testStatus!: 'pass' | 'fail' | 'skip' | 'error';
 	skipMessage?: string;
@@ -21,7 +35,12 @@ export class Result implements InternalTestResult {
 	expression: string;
 	capability: CapabilityKV[] = [];
 
-	constructor(testsName: string, groupName: string, test: Test) {
+	constructor(
+		testsName: string,
+		groupName: string,
+		test: Test,
+		groupCapability?: CapabilityKV | CapabilityKV[]
+	) {
 		this.testsName = testsName;
 		this.groupName = groupName;
 		this.testName = test.name;
@@ -56,18 +75,21 @@ export class Result implements InternalTestResult {
 			this.skipMessage = 'No output specified';
 		}
 
-		// The XML parser yields a bare object when a test declares exactly one
-		// <capability> element, and an array only for two or more. Matching on
-		// Array.isArray alone therefore dropped the capability for every
-		// single-capability test — the large majority of the suite. Normalize to an
-		// array first.
-		const testCapabilities = Array.isArray(test.capability)
-			? test.capability
-			: test.capability !== undefined && test.capability !== null
-				? [test.capability]
-				: [];
+		// A <capability> on the enclosing <group> applies to every test in it, so the
+		// capabilities a test exercises are the union of its own and its group's. Most
+		// tests restate their group's capability, in which case the union is identical to
+		// the test's own; the ones that matter are those declaring none, which would
+		// otherwise report no capabilities at all. A test's own entry wins on a repeated
+		// code, since it is the more specific declaration.
+		const merged = new Map<string, CapabilityKV>();
+		for (const capability of normalizeCapabilities(groupCapability)) {
+			merged.set(capability.code, capability);
+		}
+		for (const capability of normalizeCapabilities(test.capability)) {
+			merged.set(capability.code, capability);
+		}
 
-		this.capability = testCapabilities.map(({ code, value }) => ({ code, value }));
+		this.capability = [...merged.values()];
 	}
 }
 
@@ -91,7 +113,7 @@ export async function generateEmptyResults(
 			if (test != undefined) {
 				for (const t of test) {
 					console.log('        Test: ' + t.name);
-					const r = new Result(ts.name, group.name, t);
+					const r = new Result(ts.name, group.name, t, group.capability);
 					results.push(r);
 					groupTests.push(r);
 				}

--- a/test/results-shared.test.ts
+++ b/test/results-shared.test.ts
@@ -75,3 +75,84 @@ describe('Result capability normalization', () => {
 		expect(result.invalid).toBe('false');
 	});
 });
+
+describe('Result group capability merging', () => {
+	// A <capability> on the enclosing <group> applies to every test in it. 996 of the
+	// 1,016 groups in the suite declare one, and 1,670 tests declare none of their own —
+	// those tests reported no capabilities at all before the group's was carried through.
+	test('inherits the group capability when the test declares none', () => {
+		const result = new Result(
+			'CqlAggregateFunctionsTest',
+			'Count',
+			asTest({ name: 'CountNull', expression: 'Count({})', output: '0' }),
+			{ code: 'aggregate-functions', value: 'true' }
+		);
+
+		expect(result.capability).toStrictEqual([{ code: 'aggregate-functions', value: 'true' }]);
+	});
+
+	test('merges group and test capabilities, without duplicating a shared code', () => {
+		const result = new Result(
+			'CqlAggregateFunctionsTest',
+			'Product',
+			asTest({
+				name: 'ProductLong',
+				expression: 'Product({ 1L, 2L })',
+				output: '2L',
+				capability: [
+					{ code: 'aggregate-functions', value: 'true' },
+					{ code: 'system.long', value: 'true' },
+				],
+			}),
+			{ code: 'aggregate-functions', value: 'true' }
+		);
+
+		expect(result.capability).toStrictEqual([
+			{ code: 'aggregate-functions', value: 'true' },
+			{ code: 'system.long', value: 'true' },
+		]);
+	});
+
+	test("a test's own entry wins over the group's for the same code", () => {
+		const result = new Result(
+			'T',
+			'G',
+			asTest({
+				name: 'Override',
+				expression: '1',
+				output: '1',
+				capability: { code: 'interval-operators', value: 'false' },
+			}),
+			{ code: 'interval-operators', value: 'true' }
+		);
+
+		expect(result.capability).toStrictEqual([{ code: 'interval-operators', value: 'false' }]);
+	});
+
+	test('a single group <capability> is normalized like a test one', () => {
+		const asArray = new Result('T', 'G', asTest({ name: 'A', expression: '1', output: '1' }), [
+			{ code: 'list-operators', value: 'true' },
+		]);
+		const asObject = new Result('T', 'G', asTest({ name: 'A', expression: '1', output: '1' }), {
+			code: 'list-operators',
+			value: 'true',
+		});
+
+		expect(asObject.capability).toStrictEqual(asArray.capability);
+	});
+
+	test('no group capability leaves the test capability untouched', () => {
+		const result = new Result(
+			'T',
+			'G',
+			asTest({
+				name: 'A',
+				expression: '1',
+				output: '1',
+				capability: { code: 'arithmetic', value: 'true' },
+			})
+		);
+
+		expect(result.capability).toStrictEqual([{ code: 'arithmetic', value: 'true' }]);
+	});
+});


### PR DESCRIPTION
A `<capability>` on a `<group>` applies to every test inside it, but `Result` only ever read the test's own, so group declarations were dropped entirely. In the suite:

- **996 of 1,016 groups** declare their own `<capability>`
- **1,670 tests declare none of their own** — for those, the group's declaration was the only source, so they reported no capabilities at all

Measured against `cql-tests/tests/connectathonTests` (2,035 tests loaded), tests reporting no capability drop from **469 to 39**.

## Changes

- `results-shared.ts` — reported capabilities are now the union of the test's own and its group's, deduplicated by `code` with the test's entry winning, since it is the more specific declaration. Most tests restate their group's capability, so for them the union is identical to what was reported before; the gain is for the tests declaring none.
- The single-vs-array normalization already needed for test capabilities applies equally to group ones, so it is factored out into `normalizeCapabilities` and shared rather than duplicated.
- `test-types.ts` — `TestGroup.capability` typed `CapabilityKV | CapabilityKV[]` to match what the XML parser produces, consistent with `Test.capability`.
- The group is passed at **all three** `Result` call sites — the loader plus both server entry points — so the CLI and server paths report the same capabilities.
- Five tests added covering inheritance, merging, the same-code override, single-vs-array equivalence, and the no-group case.

`tsc --noEmit` clean, 194 tests passing. No schema change needed — this populates the existing `capabilities` field rather than adding one.

## Split out of #119

#119 carried a `groupCapability` field for this, but nothing ever emitted it, so as written it collected data that never reached the results file. This reports the capabilities through the existing field instead, and is independent of #119's timezone work.
